### PR TITLE
Added a new "LeaveDeSpawn" mechanism to pulse actions.

### DIFF
--- a/SlackMUDRPG/JSON/Characters/Chara7a76bbf-c449-45d9-be12-532a81414a56.json
+++ b/SlackMUDRPG/JSON/Characters/Chara7a76bbf-c449-45d9-be12-532a81414a56.json
@@ -1,0 +1,126 @@
+{
+  "firstname": "O",
+  "lastname": "H",
+  "lastinteractiondate": "2017-04-15T11:21:15.1600856+01:00",
+  "lastlogindate": "2017-04-15T11:33:00.0428363+01:00",
+  "age": 18,
+  "sex": "m",
+  "pkFlag": false,
+  "userID": "a7a76bbf-c449-45d9-be12-532a81414a56",
+  "username": "f",
+  "password": "EAAAAJY4+HP/LHtwZd6wPvuk9g7EjZwKp+o1u30usa1yj+4T",
+  "roomID": "Ravensmere.Military District.Ramparts Parade",
+  "newbieTipsDisabled": false,
+  "questLog": [
+    {
+      "questName": "Welcome to Ravensmere",
+      "questStep": "Visit the Clerk in the arrivals hall",
+      "lastDateUpdated": 1492251237,
+      "expires": 0,
+      "completed": true
+    }
+  ],
+  "attributes": {
+    "str": 10,
+    "int": 10,
+    "chr": 10,
+    "dex": 10,
+    "wp": 10,
+    "ft": 0,
+    "hp": 10,
+    "maxhp": 10,
+    "socialStanding": 8
+  },
+  "slots": [
+    {
+      "name": "RightHand",
+      "allowedTypes": [
+        "any"
+      ],
+      "equippedItem": {
+        "itemID": "07e053ea-964b-48ac-978f-c23ec05db4bd",
+        "singularPronoun": "a",
+        "itemName": "Key to access the arrivals hall entrance to the city",
+        "pluralName": "Keys",
+        "pluralPronoun": "some",
+        "itemType": "Misc",
+        "itemFamily": "Key",
+        "itemDescription": "Key to access the arrivals hall entrance to the city",
+        "itemWeight": 0,
+        "itemCapacity": 0,
+        "itemSize": 0,
+        "hitPoints": 1000000000,
+        "maxHitPoints": 1000000000,
+        "baseDamage": 0.001,
+        "toughness": 1,
+        "additionalData": "RavensmereAAEtoDWS"
+      }
+    },
+    {
+      "name": "LeftHand",
+      "allowedTypes": [
+        "any"
+      ]
+    },
+    {
+      "name": "Back",
+      "allowedTypes": [
+        "Container"
+      ],
+      "equippedItem": {
+        "itemID": "a8847740-30c5-4c03-b3d1-8ab103936113",
+        "singularPronoun": "a",
+        "itemName": "Small Backpack",
+        "pluralName": "Small Backpacks",
+        "pluralPronoun": "some",
+        "itemType": "Container",
+        "itemFamily": "Backpack",
+        "itemDescription": "Basic small backpack that all players start with.",
+        "itemWeight": 0,
+        "itemCapacity": 25,
+        "itemSize": 25,
+        "hitPoints": 5,
+        "maxHitPoints": 5,
+        "baseDamage": 1E-10,
+        "toughness": 1
+      }
+    }
+  ],
+  "bodyParts": [
+    {
+      "name": "Head"
+    },
+    {
+      "name": "Neck"
+    },
+    {
+      "name": "Torso"
+    },
+    {
+      "name": "Arms"
+    },
+    {
+      "name": "RightHand"
+    },
+    {
+      "name": "LeftHand"
+    },
+    {
+      "name": "Legs"
+    },
+    {
+      "name": "RightFoot"
+    },
+    {
+      "name": "LeftFoot"
+    }
+  ],
+  "currency": {
+    "amountOfCurrency": 5
+  },
+  "characterWeight": 50,
+  "characterSize": 160,
+  "connectionService": "WS",
+  "lastUsedCommand": "move RP",
+  "variableResponse": "m"
+}

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Arrivals Area.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Arrivals Area.json
@@ -21,5 +21,13 @@
       "Lockable": false
 		}
 	],
-	"RoomItems": null
+	"RoomItems": null,
+	"NPCSpawns": [
+		{
+			"TypeOfNPC": "Guard-Generic",
+			"MaxNumber": 1,
+			"SpawnFrequency": 90,
+			"Unique": false
+		}
+	]
 }

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Bridge Row.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Bridge Row.json
@@ -17,5 +17,13 @@
 			"RoomID": "Ravensmere.Military District.Ramparts Parade"
 		}
 	],
-	"RoomItems": null
+	"RoomItems": null,
+	"NPCSpawns": [
+		{
+			"TypeOfNPC": "Guard-Generic",
+			"MaxNumber": 1,
+			"SpawnFrequency": 90,
+			"Unique": false
+		}
+	]
 }

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Docklands Way South.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Docklands Way South.json
@@ -57,5 +57,13 @@
 			"RoomID": "1"
 		}
 	],
-	"RoomItems": null
+	"RoomItems": null,
+	"NPCSpawns": [
+		{
+			"TypeOfNPC": "Guard-Generic",
+			"MaxNumber": 1,
+			"SpawnFrequency": 90,
+			"Unique": false
+		}
+	]
 }

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Princes Auction House.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Princes Auction House.json
@@ -12,5 +12,13 @@
 			"RoomID": "Ravensmere.Harbour South.Ravensmere Promenade South"
 		}
 	],
-	"RoomItems": null
+	"RoomItems": null,
+	"NPCSpawns": [
+		{
+			"TypeOfNPC": "Guard-Generic",
+			"MaxNumber": 1,
+			"SpawnFrequency": 90,
+			"Unique": false
+		}
+	]
 }

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Industrial Quarter.Ravens South.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Industrial Quarter.Ravens South.json
@@ -17,5 +17,13 @@
 			"RoomID": "Ravensmere.Industrial Quarter.Ravensgate South"
 		}
 	],
-	"RoomItems": null
+	"RoomItems": null,
+	"NPCSpawns": [
+		{
+			"TypeOfNPC": "Guard-Generic",
+			"MaxNumber": 1,
+			"SpawnFrequency": 90,
+			"Unique": false
+		}
+	]
 }

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Industrial Quarter.Ravensgate South.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Industrial Quarter.Ravensgate South.json
@@ -17,5 +17,13 @@
 			"RoomID": "Ravensmere Boundary.Oldwood.Oldwood Road"
 		}
 	],
-	"RoomItems": null
+	"RoomItems": null,
+	"NPCSpawns": [
+		{
+			"TypeOfNPC": "Guard-Generic",
+			"MaxNumber": 2,
+			"SpawnFrequency": 90,
+			"Unique": false
+		}
+	]
 }

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Battle Coordinators Office.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Battle Coordinators Office.json
@@ -12,5 +12,13 @@
 			"RoomID": "Ravensmere.Military District.Grand Arena"
 		}
 	],
-	"RoomItems": null
+	"RoomItems": null,
+	"NPCSpawns": [
+		{
+			"TypeOfNPC": "Guard-Generic",
+			"MaxNumber": 1,
+			"SpawnFrequency": 90,
+			"Unique": false
+		}
+	]
 }

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Grand Parade.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Grand Parade.json
@@ -27,5 +27,13 @@
 			"RoomID": "Ravensmere.Military District.Training Ground"
 		}
 	],
-	"RoomItems": null
+	"RoomItems": null,
+	"NPCSpawns": [
+		{
+			"TypeOfNPC": "Guard-GenericComingAndGoing",
+			"MaxNumber": 6,
+			"SpawnFrequency": 90,
+			"Unique": false
+		}
+	]
 }

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Ramparts Parade.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Ramparts Parade.json
@@ -32,5 +32,13 @@
 			"RoomID": "Ravensmere.Industrial Quarter.Ravens South"
 		}
 	],
-	"RoomItems": null
+	"RoomItems": null,
+	"NPCSpawns": [
+		{
+			"TypeOfNPC": "Guard-GenericComingAndGoing",
+			"MaxNumber": 6,
+			"SpawnFrequency": 100,
+			"Unique": false
+		}
+	]
 }

--- a/SlackMUDRPG/JSON/NPCs/Guard-Generic.json
+++ b/SlackMUDRPG/JSON/NPCs/Guard-Generic.json
@@ -1,0 +1,196 @@
+﻿{
+  "firstname": "Guard",
+  "lastname": "Soldier",
+  "description": "A generic guardsman, you're unable to see much of his face due to the tight fitting helmet.",
+  "lastinteractiondate": "2016-12-31T17:28:12.0987844+00:00",
+  "lastlogindate": "2016-12-31T17:28:12.0987844+00:00",
+  "age": 22,
+  "sex": "m",
+  "PKFlag": false,
+  "UserID": "GenericGuardsman",
+  "RoomID": "IsSpawned",
+  "CurrentActivity": null,
+  "Attributes": {
+    "str": 12,
+    "int": 8,
+    "chr": 8,
+    "dex": 10,
+    "wp": 10,
+    "ft": 20,
+    "hp": 20,
+    "maxhp": 20,
+    "SocialStanding": 8
+  },
+  "Skills": [
+    {
+      "SkillName": "Sword Use",
+      "SkillLevel": 15
+    },
+    {
+      "SkillName": "Dodge",
+      "SkillLevel": 15
+    },
+    {
+      "SkillName": "Parry",
+      "SkillLevel": 15
+    }
+  ],
+  "Slots": [
+    {
+      "Name": "RightHand",
+      "AllowedTypes": [
+        "any"
+      ],
+      "EquippedItem": {
+        "ItemID": "a44a31e6-a28c-47ad-984d-ff24372b2453SergeantsSword",
+        "SingularPronoun": "an",
+        "ItemName": "Iron Sword",
+        "PluralName": "Iron Swords",
+        "PluralPronoun": "some",
+        "ItemType": "Weapon",
+        "ItemFamily": "Sword",
+        "ItemDescription": "This Iron sword is good for keeping the masses down.",
+        "ItemWeight": 2,
+        "ItemCapacity": 0,
+        "ItemSize": 2,
+        "HitPoints": 25,
+        "MaxHitPoints": 25,
+        "BaseDamage": 6.0,
+        "Toughness": 3,
+        "DestroyedOutput": null,
+        "RequiredSkills": [
+          {
+            "SkillName": "Sword Use",
+            "SkillLevel": "1"
+          }
+        ],
+        "AdditionalData": null,
+        "ObjectTrait": null,
+        "HeldItems": null
+      }
+    },
+    {
+      "Name": "LeftHand",
+      "AllowedTypes": [
+        "any"
+      ],
+      "EquippedItem": null
+    },
+    {
+      "Name": "Back",
+      "AllowedTypes": [
+        "containers"
+      ],
+      "EquippedItem": null
+    }
+  ],
+  "BodyParts": [
+    {
+      "Name": "Head"
+    },
+    {
+      "Name": "Neck"
+    },
+    {
+      "Name": "Torso"
+    },
+    {
+      "Name": "Arms"
+    },
+    {
+      "Name": "RightHand"
+    },
+    {
+      "Name": "LeftHand"
+    },
+    {
+      "Name": "Legs"
+    },
+    {
+      "Name": "RightFoot"
+    },
+    {
+      "Name": "LeftFoot"
+    }
+  ],
+  "ResponseURL": null,
+	"NPCType": "Guard-Generic",
+	"FamilyType": "Guard",
+	"IsGeneric": true,
+	"WalkingType": "walk",
+	"PronounSingular": "a",
+	"PronounMultiple": "some",
+  "NPCResponses": [
+    {
+      "ResponseType": "PlayerCharacter.ExaminesThem",
+      "ResponseTimeOfDay": "all",
+      "AdditionalData": null,
+      "Faction": null,
+      "Frequency": 50,
+      "ResponseSteps": [
+        {
+          "ResponseStepType": "Conversation",
+          "ResponseStepData": "Examines.1"
+        }
+      ]
+    },
+    {
+      "ResponseType": "PlayerCharacter.Attack",
+      "ResponseTimeOfDay": "all",
+      "AdditionalData": null,
+      "Faction": null,
+      "Frequency": 100,
+      "ResponseSteps": [
+				{
+					"ResponseStepType": "Conversation",
+					"ResponseStepData": "Attack.1"
+				},
+				{
+          "ResponseStepType": "Attack",
+          "ResponseStepData": null
+        }
+      ]
+    },
+    {
+      "ResponseType": "Pulse",
+      "ResponseTimeOfDay": "all",
+      "AdditionalData": "AllPeople",
+      "Faction": null,
+      "Frequency": 10,
+      "ResponseSteps": [
+        {
+          "ResponseStepType": "LeaveDeSpawn",
+          "ResponseStepData": null
+        }
+      ]
+    }
+  ],
+  "NPCConversationStructures": [
+    {
+      "ConversationID": "Examines",
+      "ConversationStep": [
+        {
+          "StepID": "1",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Move along citizen.",
+          "NextStep": null,
+          "ResponseOptions": null
+        }
+      ]
+    },
+    {
+      "ConversationID": "Attack",
+      "ConversationStep": [
+        {
+          "StepID": "1",
+          "Scope": "shout",
+          "AdditionalData": "To Arms!  To Arms!",
+          "NextStep": null,
+          "ResponseOptions": null
+        }
+      ]
+    }
+  ],
+  "NPCMovementAlgorithms": null,
+  "NPCMovementTarget": null
+}

--- a/SlackMUDRPG/JSON/NPCs/Guard-GenericComingAndGoing.json
+++ b/SlackMUDRPG/JSON/NPCs/Guard-GenericComingAndGoing.json
@@ -1,0 +1,196 @@
+﻿{
+  "firstname": "Guard",
+  "lastname": "Soldier",
+  "description": "A generic guardsman, you're unable to see much of his face due to the tight fitting helmet.",
+  "lastinteractiondate": "2016-12-31T17:28:12.0987844+00:00",
+  "lastlogindate": "2016-12-31T17:28:12.0987844+00:00",
+  "age": 22,
+  "sex": "m",
+  "PKFlag": false,
+  "UserID": "GenericGuardsmanComingandGoing",
+  "RoomID": "IsSpawned",
+  "CurrentActivity": null,
+  "Attributes": {
+    "str": 12,
+    "int": 8,
+    "chr": 8,
+    "dex": 10,
+    "wp": 10,
+    "ft": 20,
+    "hp": 20,
+    "maxhp": 20,
+    "SocialStanding": 8
+  },
+  "Skills": [
+    {
+      "SkillName": "Sword Use",
+      "SkillLevel": 15
+    },
+    {
+      "SkillName": "Dodge",
+      "SkillLevel": 15
+    },
+    {
+      "SkillName": "Parry",
+      "SkillLevel": 15
+    }
+  ],
+  "Slots": [
+    {
+      "Name": "RightHand",
+      "AllowedTypes": [
+        "any"
+      ],
+      "EquippedItem": {
+        "ItemID": "a44a31e6-a28c-47ad-984d-ff24372b2453SergeantsSword",
+        "SingularPronoun": "an",
+        "ItemName": "Iron Sword",
+        "PluralName": "Iron Swords",
+        "PluralPronoun": "some",
+        "ItemType": "Weapon",
+        "ItemFamily": "Sword",
+        "ItemDescription": "This Iron sword is good for keeping the masses down.",
+        "ItemWeight": 2,
+        "ItemCapacity": 0,
+        "ItemSize": 2,
+        "HitPoints": 25,
+        "MaxHitPoints": 25,
+        "BaseDamage": 6.0,
+        "Toughness": 3,
+        "DestroyedOutput": null,
+        "RequiredSkills": [
+          {
+            "SkillName": "Sword Use",
+            "SkillLevel": "1"
+          }
+        ],
+        "AdditionalData": null,
+        "ObjectTrait": null,
+        "HeldItems": null
+      }
+    },
+    {
+      "Name": "LeftHand",
+      "AllowedTypes": [
+        "any"
+      ],
+      "EquippedItem": null
+    },
+    {
+      "Name": "Back",
+      "AllowedTypes": [
+        "containers"
+      ],
+      "EquippedItem": null
+    }
+  ],
+  "BodyParts": [
+    {
+      "Name": "Head"
+    },
+    {
+      "Name": "Neck"
+    },
+    {
+      "Name": "Torso"
+    },
+    {
+      "Name": "Arms"
+    },
+    {
+      "Name": "RightHand"
+    },
+    {
+      "Name": "LeftHand"
+    },
+    {
+      "Name": "Legs"
+    },
+    {
+      "Name": "RightFoot"
+    },
+    {
+      "Name": "LeftFoot"
+    }
+  ],
+  "ResponseURL": null,
+	"NPCType": "Guard-GenericComingAndGoing",
+	"FamilyType": "Guard",
+	"IsGeneric": true,
+	"WalkingType": "walk",
+	"PronounSingular": "a",
+	"PronounMultiple": "some",
+  "NPCResponses": [
+    {
+      "ResponseType": "PlayerCharacter.ExaminesThem",
+      "ResponseTimeOfDay": "all",
+      "AdditionalData": null,
+      "Faction": null,
+      "Frequency": 50,
+      "ResponseSteps": [
+        {
+          "ResponseStepType": "Conversation",
+          "ResponseStepData": "Examines.1"
+        }
+      ]
+    },
+    {
+      "ResponseType": "PlayerCharacter.Attack",
+      "ResponseTimeOfDay": "all",
+      "AdditionalData": null,
+      "Faction": null,
+      "Frequency": 100,
+      "ResponseSteps": [
+				{
+					"ResponseStepType": "Conversation",
+					"ResponseStepData": "Attack.1"
+				},
+				{
+          "ResponseStepType": "Attack",
+          "ResponseStepData": null
+        }
+      ]
+    },
+    {
+      "ResponseType": "Pulse",
+      "ResponseTimeOfDay": "all",
+      "AdditionalData": "AllPeople",
+      "Faction": null,
+      "Frequency": 45,
+      "ResponseSteps": [
+        {
+          "ResponseStepType": "LeaveDeSpawn",
+          "ResponseStepData": null
+        }
+      ]
+    }
+  ],
+  "NPCConversationStructures": [
+    {
+      "ConversationID": "Examines",
+      "ConversationStep": [
+        {
+          "StepID": "1",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Move along citizen.",
+          "NextStep": null,
+          "ResponseOptions": null
+        }
+      ]
+    },
+    {
+      "ConversationID": "Attack",
+      "ConversationStep": [
+        {
+          "StepID": "1",
+          "Scope": "shout",
+          "AdditionalData": "To Arms!  To Arms!",
+          "NextStep": null,
+          "ResponseOptions": null
+        }
+      ]
+    }
+  ],
+  "NPCMovementAlgorithms": null,
+  "NPCMovementTarget": null
+}

--- a/SlackMUDRPG/SlackMUDRPG.csproj
+++ b/SlackMUDRPG/SlackMUDRPG.csproj
@@ -299,6 +299,8 @@
     <Content Include="Handlers\GameAccess.ashx" />
     <Content Include="JSON\Misc\Currency.BaseCharacter.json" />
     <Content Include="JSON\NPCs\Bert Rengle.json" />
+    <Content Include="JSON\NPCs\Guard-Generic.json" />
+    <Content Include="JSON\NPCs\Guard-GenericComingAndGoing.json" />
     <None Include="JSON\Objects\Consumable.SimpleArrow.json" />
     <Content Include="JSON\Skills\Skill.Skin.json" />
     <Content Include="JSON\Objects\Weapon.Knife.json" />


### PR DESCRIPTION
Added two new types of NPC:
The "Generic Guard" - who just generally stands around guarding areas.
The "Generic Guard - Coming and going" - who stands around a bit, but will sometimes leave.. creating the impression of movement in the world - only used around the military district at the moment.
It's worth noting that both guard types do despawn, but the generic guard as a much lower chance of doing so... and in general, because of the set up of those guard types, would only leave an area unguarded for a max of two minutes.  We will be able to have guards spawn in places they shouldn't *very* rarely if we wanted as well - and then have them leave very quickly again (as if just passing through).