### PR TITLE
Added a checking mechanism to allow NPCs to check character names and…

### DIFF
--- a/SlackMUDRPG/CommandClasses/SMAccount.cs
+++ b/SlackMUDRPG/CommandClasses/SMAccount.cs
@@ -1,0 +1,128 @@
+﻿using Newtonsoft.Json;
+using SlackMUDRPG.Utility;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Web;
+
+namespace SlackMUDRPG.CommandClasses
+{
+    public class SMAccount
+    {
+        [JsonProperty("EmailAddress")]
+        public string EmailAddress { get; set; }
+
+        [JsonProperty("HashedPassword")]
+        public string HashedPassword { get; set; }
+
+        [JsonProperty("AccountReference")]
+        public string AccountReference { get; set; }
+    }
+
+    public class SMCharacterName
+    {
+        [JsonProperty("CharacterName")]
+        public string CharacterName { get; set; }
+
+        [JsonProperty("AccountReference")]
+        public string AccountReference { get; set; }
+    }
+
+    public class SMAccountHelper
+    {
+        /// <summary>
+        /// Checks that a character name can be used (i.e. hasn't already been used).
+        /// </summary>
+        /// <param name="fullCharName">The full name of the character being checked</param>
+        /// <returns></returns>
+        public bool CheckCharNameCanBeUsed(string fullCharName)
+        {
+            // Load the char names list into memory
+            string path = FilePathSystem.GetFilePath("Characters", "CharNamesList");
+            List<SMCharacterName> allCharacters = new List<SMCharacterName>();
+
+            if (File.Exists(path))
+            {
+                using (StreamReader r = new StreamReader(path))
+                {
+                    string json = r.ReadToEnd();
+                    allCharacters = JsonConvert.DeserializeObject<List<SMCharacterName>>(json);
+                }
+            }
+
+            // Select the name from the list
+            SMCharacterName smcn = allCharacters.FirstOrDefault(c => c.CharacterName.ToLower() == fullCharName.ToLower());
+
+            // if the name doesn't exist...
+            if (smcn == null)
+            {
+                // Load the char names list into memory
+                path = FilePathSystem.GetFilePath("NPCs", "NPCNamesList");
+                List<SMCharacterName> npcCharacters = new List<SMCharacterName>();
+
+                if (File.Exists(path))
+                {
+                    using (StreamReader r = new StreamReader(path))
+                    {
+                        string json = r.ReadToEnd();
+                        npcCharacters = JsonConvert.DeserializeObject<List<SMCharacterName>>(json);
+                    }
+                }
+
+                // Select the name from the list
+                SMCharacterName npccn = npcCharacters.FirstOrDefault(c => c.CharacterName.ToLower() == fullCharName.ToLower());
+
+                if (npccn == null)
+                {
+                    return true; // .. the name can be used
+                }
+                else
+                {
+                    return false; // can't use the name as an NPC has it already.
+                }
+            }
+            else 
+            {
+                return false; // .. the name can't be used as a player has used it.
+            }
+        }
+
+        /// <summary>
+        /// Adds the name to the CharNamesList
+        /// </summary>
+        /// <param name="fullCharName">The full name of the character being added</param>
+        /// <returns></returns>
+        public void AddNameToList(string fullCharName, string accountReference)
+        {
+            // Load the char names list into memory
+            string path = FilePathSystem.GetFilePath("Characters", "CharNamesList");
+            List<SMCharacterName> allCharacters = new List<SMCharacterName>();
+
+            if (File.Exists(path))
+            {
+                using (StreamReader r = new StreamReader(path))
+                {
+                    string json = r.ReadToEnd();
+                    allCharacters = JsonConvert.DeserializeObject<List<SMCharacterName>>(json);
+                }
+            }
+
+            // Create a new character reference
+            SMCharacterName smcn = new SMCharacterName();
+            smcn.CharacterName = fullCharName;
+            smcn.AccountReference = accountReference;
+
+            // Add the character to the list
+            allCharacters.Add(smcn);
+
+            // Save the list to disk.
+            string listJSON = JsonConvert.SerializeObject(allCharacters, Formatting.Indented);
+
+            using (StreamWriter w = new StreamWriter(path))
+            {
+                w.WriteLine(listJSON);
+            }
+        }
+    }
+}

--- a/SlackMUDRPG/CommandClasses/SMNPC.cs
+++ b/SlackMUDRPG/CommandClasses/SMNPC.cs
@@ -367,25 +367,52 @@ namespace SlackMUDRPG.CommandClasses
 							}
 						}
 						break;
-					case "setplayerattribute":
-						// Add a response option
-						string s = invokingCharacter.VariableResponse.ToLower();
-						switch (npccs.AdditionalData.ToLower())
-						{
-							case "firstname":
-								invokingCharacter.FirstName = char.ToUpper(s[0]) + s.Substring(1);
-								break;
-							case "lastname":
-								invokingCharacter.LastName = char.ToUpper(s[0]) + s.Substring(1);
-								break;
-							case "sex":
-								invokingCharacter.Sex = char.Parse(invokingCharacter.VariableResponse);
-								break;
-						}
-						invokingCharacter.SaveToApplication();
-						invokingCharacter.SaveToFile();
-						break;
-					case "setvariableresponse":
+                    case "setplayerattribute":
+                        // Add a response option
+                        string s = invokingCharacter.VariableResponse.ToLower();
+                        switch (npccs.AdditionalData.ToLower())
+                        {
+                            case "firstname":
+                                invokingCharacter.FirstName = char.ToUpper(s[0]) + s.Substring(1);
+                                break;
+                            case "lastname":
+                                invokingCharacter.LastName = char.ToUpper(s[0]) + s.Substring(1);
+                                break;
+                            case "sex":
+                                invokingCharacter.Sex = char.Parse(invokingCharacter.VariableResponse);
+                                break;
+                        }
+                        invokingCharacter.SaveToApplication();
+                        invokingCharacter.SaveToFile();
+                        break;
+                    case "checkplayername":
+                        // Gather the info
+                        string[] nextStepsCheckPlayerName = npccs.AdditionalData.Split('|');
+                        string name = invokingCharacter.GetFullName();
+                        bool nameCanBeUsed = new SMAccountHelper().CheckCharNameCanBeUsed(name);
+                        
+                        if (nameCanBeUsed)
+                        {
+                            // Add the name to the list so no one else can use it
+                            new SMAccountHelper().AddNameToList(name, invokingCharacter.UserID);
+
+                            // Play the succcess conversation step
+                            ProcessConversationStep(npcc, nextStepsCheckPlayerName[0], invokingCharacter);
+                        }
+                        else
+                        {
+                            // Reset the player name
+                            invokingCharacter.FirstName = "New";
+                            invokingCharacter.LastName = "Arrival";
+                            invokingCharacter.SaveToApplication();
+                            invokingCharacter.SaveToFile();
+
+                            // Play the failure conversaton steps (i.e. go back through the same thing again).
+                            ProcessConversationStep(npcc, nextStepsCheckPlayerName[1], invokingCharacter);
+                        }
+                        
+                        break;
+                    case "setvariableresponse":
 						invokingCharacter.VariableResponse = npccs.AdditionalData.ToLower();
 						break;
 					case "teachskill":

--- a/SlackMUDRPG/Global.asax.cs
+++ b/SlackMUDRPG/Global.asax.cs
@@ -133,16 +133,19 @@ namespace SlackMUDRPG
 			Files = d.GetFiles();
 			foreach (FileInfo file in Files)
 			{
-				string NPCFilePath = FilePathSystem.GetFilePath("NPCs", file.Name, "");
-				// Use a stream reader to read the file in (based on the path)
-				using (StreamReader r = new StreamReader(NPCFilePath))
-				{
-					// Create a new JSON string to be used...
-					string json = r.ReadToEnd();
-
-					// ... get the information from the help file
-					lnpcs.Add(JsonConvert.DeserializeObject<SMNPC>(json));
-				}
+                if (file.Name != "NPCNamesList.json")
+                {
+                    string NPCFilePath = FilePathSystem.GetFilePath("NPCs", file.Name, "");
+                    // Use a stream reader to read the file in (based on the path)
+                    using (StreamReader r = new StreamReader(NPCFilePath))
+                    {
+                        // Create a new JSON string to be used...
+                        string json = r.ReadToEnd();
+                        
+                        // ... get the information from the help file
+                        lnpcs.Add(JsonConvert.DeserializeObject<SMNPC>(json));
+                    }
+                }
 			}
 
 			Application["SMNPCs"] = lnpcs;

--- a/SlackMUDRPG/JSON/Characters/Char25b611f9-0922-4f50-abde-e6abccf99372.json
+++ b/SlackMUDRPG/JSON/Characters/Char25b611f9-0922-4f50-abde-e6abccf99372.json
@@ -1,0 +1,127 @@
+{
+  "firstname": "Bert",
+  "lastname": "Somethingelse",
+  "lastinteractiondate": "2017-04-16T15:10:41.3800784+01:00",
+  "lastlogindate": "2017-04-16T15:09:18.5589466+01:00",
+  "age": 18,
+  "sex": "m",
+  "pkFlag": false,
+  "userID": "25b611f9-0922-4f50-abde-e6abccf99372",
+  "username": "g",
+  "password": "EAAAAC5leycl7wXoKTp9/C8NE2+o0f93a9ltkjZEOXR3n+eO",
+  "roomID": "Ravensmere.Harbour South.Arrivals Area",
+  "newbieTipsDisabled": false,
+  "questLog": [
+    {
+      "questName": "Welcome to Ravensmere",
+      "questStep": "Visit the Clerk in the arrivals hall",
+      "lastDateUpdated": 1492351238,
+      "expires": 0,
+      "completed": true
+    }
+  ],
+  "attributes": {
+    "str": 10,
+    "int": 10,
+    "chr": 10,
+    "dex": 10,
+    "wp": 10,
+    "ft": 0,
+    "hp": 10,
+    "maxhp": 10,
+    "socialStanding": 8
+  },
+  "slots": [
+    {
+      "name": "RightHand",
+      "allowedTypes": [
+        "any"
+      ],
+      "equippedItem": {
+        "itemID": "77c6d92b-1442-4cbf-952a-3c8d70df5a71",
+        "singularPronoun": "a",
+        "itemName": "Key to access the arrivals hall entrance to the city",
+        "pluralName": "Keys",
+        "pluralPronoun": "some",
+        "itemType": "Misc",
+        "itemFamily": "Key",
+        "itemDescription": "Key to access the arrivals hall entrance to the city",
+        "itemWeight": 0,
+        "itemCapacity": 0,
+        "itemSize": 0,
+        "hitPoints": 1000000000,
+        "maxHitPoints": 1000000000,
+        "baseDamage": 0.001,
+        "toughness": 1,
+        "additionalData": "RavensmereAAEtoDWS"
+      }
+    },
+    {
+      "name": "LeftHand",
+      "allowedTypes": [
+        "any"
+      ]
+    },
+    {
+      "name": "Back",
+      "allowedTypes": [
+        "Container"
+      ],
+      "equippedItem": {
+        "itemID": "121fd45a-be03-4d28-a7e8-9deba005b4ec",
+        "singularPronoun": "a",
+        "itemName": "Small Backpack",
+        "pluralName": "Small Backpacks",
+        "pluralPronoun": "some",
+        "itemType": "Container",
+        "itemFamily": "Backpack",
+        "itemDescription": "Basic small backpack that all players start with.",
+        "itemWeight": 0,
+        "itemCapacity": 25,
+        "itemSize": 25,
+        "hitPoints": 5,
+        "maxHitPoints": 5,
+        "baseDamage": 1E-10,
+        "toughness": 1
+      }
+    }
+  ],
+  "bodyParts": [
+    {
+      "name": "Head"
+    },
+    {
+      "name": "Neck"
+    },
+    {
+      "name": "Torso"
+    },
+    {
+      "name": "Arms"
+    },
+    {
+      "name": "RightHand"
+    },
+    {
+      "name": "LeftHand"
+    },
+    {
+      "name": "Legs"
+    },
+    {
+      "name": "RightFoot"
+    },
+    {
+      "name": "LeftFoot"
+    }
+  ],
+  "currency": {
+    "amountOfCurrency": 5
+  },
+  "characterWeight": 50,
+  "characterSize": 160,
+  "connectionService": "WS",
+  "lastUsedCommand": "resp Y",
+  "variableResponse": "m",
+  "npCsWaitingForResponses": []
+}

--- a/SlackMUDRPG/JSON/Characters/Char2610e551-f63a-4d1b-89b8-cc56264ca662.json
+++ b/SlackMUDRPG/JSON/Characters/Char2610e551-f63a-4d1b-89b8-cc56264ca662.json
@@ -1,0 +1,96 @@
+{
+  "firstname": "New",
+  "lastname": "Arrival",
+  "lastinteractiondate": "2017-04-16T14:58:38.266796+01:00",
+  "lastlogindate": "2017-04-16T14:58:38.266796+01:00",
+  "age": 18,
+  "sex": "m",
+  "pkFlag": false,
+  "userID": "2610e551-f63a-4d1b-89b8-cc56264ca662",
+  "username": "ddwad",
+  "password": "EAAAABZrlQJfk+SQF+oYyUGQBwGiNOYDLJfqZmsQjLrkD7HJ",
+  "roomID": "Ravensmere.Harbour South.Landing Area",
+  "newbieTipsDisabled": false,
+  "attributes": {
+    "str": 10,
+    "int": 10,
+    "chr": 10,
+    "dex": 10,
+    "wp": 10,
+    "ft": 0,
+    "hp": 10,
+    "maxhp": 10,
+    "socialStanding": 8
+  },
+  "slots": [
+    {
+      "name": "RightHand",
+      "allowedTypes": [
+        "any"
+      ]
+    },
+    {
+      "name": "LeftHand",
+      "allowedTypes": [
+        "any"
+      ]
+    },
+    {
+      "name": "Back",
+      "allowedTypes": [
+        "Container"
+      ],
+      "equippedItem": {
+        "itemID": "4c58f24a-1fcf-467b-a6fe-96c6334d5c78",
+        "singularPronoun": "a",
+        "itemName": "Small Backpack",
+        "pluralName": "Small Backpacks",
+        "pluralPronoun": "some",
+        "itemType": "Container",
+        "itemFamily": "Backpack",
+        "itemDescription": "Basic small backpack that all players start with.",
+        "itemWeight": 0,
+        "itemCapacity": 25,
+        "itemSize": 25,
+        "hitPoints": 5,
+        "maxHitPoints": 5,
+        "baseDamage": 1E-10,
+        "toughness": 1
+      }
+    }
+  ],
+  "bodyParts": [
+    {
+      "name": "Head"
+    },
+    {
+      "name": "Neck"
+    },
+    {
+      "name": "Torso"
+    },
+    {
+      "name": "Arms"
+    },
+    {
+      "name": "RightHand"
+    },
+    {
+      "name": "LeftHand"
+    },
+    {
+      "name": "Legs"
+    },
+    {
+      "name": "RightFoot"
+    },
+    {
+      "name": "LeftFoot"
+    }
+  ],
+  "currency": {
+    "amountOfCurrency": 5
+  },
+  "characterWeight": 50,
+  "characterSize": 160
+}

--- a/SlackMUDRPG/JSON/Characters/CharNamesList.json
+++ b/SlackMUDRPG/JSON/Characters/CharNamesList.json
@@ -1,0 +1,10 @@
+[
+  {
+    "characterName": "Bert Somethingelse",
+    "accountReference": "25b611f9-0922-4f50-abde-e6abccf99372"
+  },
+  {
+    "characterName": "Bert Jay",
+    "accountReference": "d55f4db9-5c36-430e-a91a-97160e88d4f1"
+  }
+]

--- a/SlackMUDRPG/JSON/Characters/Chara7a76bbf-c449-45d9-be12-532a81414a56.json
+++ b/SlackMUDRPG/JSON/Characters/Chara7a76bbf-c449-45d9-be12-532a81414a56.json
@@ -1,15 +1,15 @@
 {
   "firstname": "O",
   "lastname": "H",
-  "lastinteractiondate": "2017-04-15T15:32:06.3664984+01:00",
-  "lastlogindate": "2017-04-15T15:33:27.7098636+01:00",
+  "lastinteractiondate": "2017-04-16T14:57:19.5458421+01:00",
+  "lastlogindate": "2017-04-16T14:56:50.9398321+01:00",
   "age": 18,
   "sex": "m",
   "pkFlag": false,
   "userID": "a7a76bbf-c449-45d9-be12-532a81414a56",
   "username": "f",
   "password": "EAAAAJY4+HP/LHtwZd6wPvuk9g7EjZwKp+o1u30usa1yj+4T",
-  "roomID": "Ravensmere.Harbour South.Arrivals Area",
+  "roomID": "Ravensmere.Harbour South.Landing Area",
   "newbieTipsDisabled": false,
   "questLog": [
     {
@@ -150,6 +150,6 @@
   "characterWeight": 50,
   "characterSize": 160,
   "connectionService": "WS",
-  "lastUsedCommand": "move AA",
+  "lastUsedCommand": "move AAE",
   "variableResponse": "m"
 }

--- a/SlackMUDRPG/JSON/Characters/Chard55f4db9-5c36-430e-a91a-97160e88d4f1.json
+++ b/SlackMUDRPG/JSON/Characters/Chard55f4db9-5c36-430e-a91a-97160e88d4f1.json
@@ -1,0 +1,126 @@
+{
+  "firstname": "Bert",
+  "lastname": "Jay",
+  "lastinteractiondate": "2017-04-16T15:40:29.5934793+01:00",
+  "lastlogindate": "2017-04-16T15:39:30.2971218+01:00",
+  "age": 18,
+  "sex": "m",
+  "pkFlag": false,
+  "userID": "d55f4db9-5c36-430e-a91a-97160e88d4f1",
+  "username": "aa",
+  "password": "EAAAAGiOAnVYoX8Sv9HlF0fU9rWyeuILro0V09AfzbyWk5Ei",
+  "roomID": "Ravensmere.Harbour South.Docklands Way South",
+  "newbieTipsDisabled": false,
+  "questLog": [
+    {
+      "questName": "Welcome to Ravensmere",
+      "questStep": "Visit the Clerk in the arrivals hall",
+      "lastDateUpdated": 1492353572,
+      "expires": 0,
+      "completed": true
+    }
+  ],
+  "attributes": {
+    "str": 10,
+    "int": 10,
+    "chr": 10,
+    "dex": 10,
+    "wp": 10,
+    "ft": 0,
+    "hp": 10,
+    "maxhp": 10,
+    "socialStanding": 8
+  },
+  "slots": [
+    {
+      "name": "RightHand",
+      "allowedTypes": [
+        "any"
+      ],
+      "equippedItem": {
+        "itemID": "856909e9-1655-4895-8854-8ed92208a07e",
+        "singularPronoun": "a",
+        "itemName": "Key to access the arrivals hall entrance to the city",
+        "pluralName": "Keys",
+        "pluralPronoun": "some",
+        "itemType": "Misc",
+        "itemFamily": "Key",
+        "itemDescription": "Key to access the arrivals hall entrance to the city",
+        "itemWeight": 0,
+        "itemCapacity": 0,
+        "itemSize": 0,
+        "hitPoints": 1000000000,
+        "maxHitPoints": 1000000000,
+        "baseDamage": 0.001,
+        "toughness": 1,
+        "additionalData": "RavensmereAAEtoDWS"
+      }
+    },
+    {
+      "name": "LeftHand",
+      "allowedTypes": [
+        "any"
+      ]
+    },
+    {
+      "name": "Back",
+      "allowedTypes": [
+        "Container"
+      ],
+      "equippedItem": {
+        "itemID": "7de4b8f4-5283-4a03-9957-709dcd8fbfe0",
+        "singularPronoun": "a",
+        "itemName": "Small Backpack",
+        "pluralName": "Small Backpacks",
+        "pluralPronoun": "some",
+        "itemType": "Container",
+        "itemFamily": "Backpack",
+        "itemDescription": "Basic small backpack that all players start with.",
+        "itemWeight": 0,
+        "itemCapacity": 25,
+        "itemSize": 25,
+        "hitPoints": 5,
+        "maxHitPoints": 5,
+        "baseDamage": 1E-10,
+        "toughness": 1
+      }
+    }
+  ],
+  "bodyParts": [
+    {
+      "name": "Head"
+    },
+    {
+      "name": "Neck"
+    },
+    {
+      "name": "Torso"
+    },
+    {
+      "name": "Arms"
+    },
+    {
+      "name": "RightHand"
+    },
+    {
+      "name": "LeftHand"
+    },
+    {
+      "name": "Legs"
+    },
+    {
+      "name": "RightFoot"
+    },
+    {
+      "name": "LeftFoot"
+    }
+  ],
+  "currency": {
+    "amountOfCurrency": 5
+  },
+  "characterWeight": 50,
+  "characterSize": 160,
+  "connectionService": "WS",
+  "lastUsedCommand": "move DWS",
+  "variableResponse": "m"
+}

--- a/SlackMUDRPG/JSON/Characters/Chardd1320e0-23b2-4d7d-813b-bb95956b73da.json
+++ b/SlackMUDRPG/JSON/Characters/Chardd1320e0-23b2-4d7d-813b-bb95956b73da.json
@@ -1,0 +1,96 @@
+{
+  "firstname": "New",
+  "lastname": "Arrival",
+  "lastinteractiondate": "2017-04-16T14:58:05.4125635+01:00",
+  "lastlogindate": "2017-04-16T14:58:05.4125635+01:00",
+  "age": 18,
+  "sex": "m",
+  "pkFlag": false,
+  "userID": "dd1320e0-23b2-4d7d-813b-bb95956b73da",
+  "username": "aa",
+  "password": "EAAAAJUCu3DvA3upZV5DgnzDdeOg9MdsDlLR1jWEvkE8kqTZ",
+  "roomID": "Ravensmere.Harbour South.Landing Area",
+  "newbieTipsDisabled": false,
+  "attributes": {
+    "str": 10,
+    "int": 10,
+    "chr": 10,
+    "dex": 10,
+    "wp": 10,
+    "ft": 0,
+    "hp": 10,
+    "maxhp": 10,
+    "socialStanding": 8
+  },
+  "slots": [
+    {
+      "name": "RightHand",
+      "allowedTypes": [
+        "any"
+      ]
+    },
+    {
+      "name": "LeftHand",
+      "allowedTypes": [
+        "any"
+      ]
+    },
+    {
+      "name": "Back",
+      "allowedTypes": [
+        "Container"
+      ],
+      "equippedItem": {
+        "itemID": "5c5e13ce-4071-4b35-a326-310fbb4d2bf5",
+        "singularPronoun": "a",
+        "itemName": "Small Backpack",
+        "pluralName": "Small Backpacks",
+        "pluralPronoun": "some",
+        "itemType": "Container",
+        "itemFamily": "Backpack",
+        "itemDescription": "Basic small backpack that all players start with.",
+        "itemWeight": 0,
+        "itemCapacity": 25,
+        "itemSize": 25,
+        "hitPoints": 5,
+        "maxHitPoints": 5,
+        "baseDamage": 1E-10,
+        "toughness": 1
+      }
+    }
+  ],
+  "bodyParts": [
+    {
+      "name": "Head"
+    },
+    {
+      "name": "Neck"
+    },
+    {
+      "name": "Torso"
+    },
+    {
+      "name": "Arms"
+    },
+    {
+      "name": "RightHand"
+    },
+    {
+      "name": "LeftHand"
+    },
+    {
+      "name": "Legs"
+    },
+    {
+      "name": "RightFoot"
+    },
+    {
+      "name": "LeftFoot"
+    }
+  ],
+  "currency": {
+    "amountOfCurrency": 5
+  },
+  "characterWeight": 50,
+  "characterSize": 160
+}

--- a/SlackMUDRPG/JSON/NPCs/NPCNamesList.json
+++ b/SlackMUDRPG/JSON/NPCs/NPCNamesList.json
@@ -1,0 +1,34 @@
+[
+  {
+    "characterName": "Derick Felhirst",
+    "accountReference": "NPC"
+  },
+  {
+    "characterName": "Bert Rengle",
+    "accountReference": "NPC"
+  },
+  {
+    "characterName": "Guard Soldier",
+    "accountReference": "NPC"
+  },
+  {
+    "characterName": "MasterSmith Duncan",
+    "accountReference": "NPC"
+  },
+  {
+    "characterName": "Mr Zog",
+    "accountReference": "NPC"
+  },
+  {
+    "characterName": "Podgy Clerk",
+    "accountReference": "NPC"
+  },
+  {
+    "characterName": "New Arrival",
+    "accountReference": "NPC"
+  },
+  {
+    "characterName": "Bert Somethingelse",
+    "accountReference": "25b611f9-0922-4f50-abde-e6abccf99372"
+  }
+]

--- a/SlackMUDRPG/JSON/NPCs/PodgyClerk.json
+++ b/SlackMUDRPG/JSON/NPCs/PodgyClerk.json
@@ -294,13 +294,27 @@
 						}
 					]
 				},
-				{
-					"StepID": "4-8",
-					"Scope": "setplayerattribute",
-					"AdditionalData": "lastname",
-					"NextStep": "4-9.0",
-					"ResponseOptions": null
-				},
+        {
+          "StepID": "4-8",
+          "Scope": "setplayerattribute",
+          "AdditionalData": "lastname",
+          "NextStep": "4-8Check.0",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "4-8Check",
+          "Scope": "checkplayername",
+          "AdditionalData": "4-9|4-8CheckCantUse",
+          "NextStep": null,
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "4-8CheckCantUse",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Hrm, looking at my records that name has already been used.. please choose another..",
+          "NextStep": "4-2.1",
+          "ResponseOptions": null
+        },
 				{
 					"StepID": "4-9",
 					"Scope": "saytoplayer",

--- a/SlackMUDRPG/SlackMUDRPG.csproj
+++ b/SlackMUDRPG/SlackMUDRPG.csproj
@@ -304,6 +304,8 @@
     <Content Include="JSON\NPCs\Beggar.json" />
     <Content Include="JSON\NPCs\Mr Zog.json" />
     <Content Include="JSON\NPCs\MasterSmith Duncan.json" />
+    <Content Include="JSON\Characters\CharNamesList.json" />
+    <Content Include="JSON\NPCs\NPCNamesList.json" />
     <None Include="JSON\Objects\Consumable.SimpleArrow.json" />
     <Content Include="JSON\Skills\Skill.Skin.json" />
     <Content Include="JSON\Objects\Weapon.Knife.json" />
@@ -393,6 +395,7 @@
     <Compile Include="CommandClasses\Commands.cs" />
     <Compile Include="CommandClasses\SlackClient.cs" />
     <Compile Include="CommandClasses\SlackMud.cs" />
+    <Compile Include="CommandClasses\SMAccount.cs" />
     <Compile Include="CommandClasses\SMAttributes.cs" />
     <Compile Include="CommandClasses\SMBodyPart.cs" />
     <Compile Include="CommandClasses\SMCharacter.cs" />


### PR DESCRIPTION
… reset them if they've already been used.

Two new files created:
Characters/CharNamesList.json, containing a list of all characters.
NPCs/NPCNamesList.json, containing a list of all the NPCs.
Both the files are checked when checking names are valid (they're in two folders as we'll be changing the NPC one as we add more content and we don't want the live characters list to be updated with the one we have in our dev version!)
Updated the Podgy Clerk to now have a name check part to his character naming process.
Updated the global file to stop the NPCNamesList from being added as an NPC (well, it can't really, it just breaks the whole application).