### PR TITLE
Enabled players to update their username and password attached to the…

### DIFF
--- a/SlackMUDRPG/CommandClasses/SMAccount.cs
+++ b/SlackMUDRPG/CommandClasses/SMAccount.cs
@@ -10,23 +10,26 @@ namespace SlackMUDRPG.CommandClasses
 {
     public class SMAccount
     {
+        [JsonProperty("CharacterName")]
+        public string CharacterName { get; set; }
+
+        [JsonProperty("AccountReference")]
+        public string AccountReference { get; set; }
+
         [JsonProperty("EmailAddress")]
         public string EmailAddress { get; set; }
 
         [JsonProperty("HashedPassword")]
         public string HashedPassword { get; set; }
 
-        [JsonProperty("AccountReference")]
-        public string AccountReference { get; set; }
+        [JsonProperty("OtherReference")]
+        public List<SMAccountOtherReference> OtherReference { get; set; }
     }
 
-    public class SMCharacterName
+    public class SMAccountOtherReference
     {
-        [JsonProperty("CharacterName")]
-        public string CharacterName { get; set; }
-
-        [JsonProperty("AccountReference")]
-        public string AccountReference { get; set; }
+        [JsonProperty("OtherReference")]
+        public string OtherReference { get; set; }
     }
 
     public class SMAccountHelper
@@ -40,38 +43,38 @@ namespace SlackMUDRPG.CommandClasses
         {
             // Load the char names list into memory
             string path = FilePathSystem.GetFilePath("Characters", "CharNamesList");
-            List<SMCharacterName> allCharacters = new List<SMCharacterName>();
+            List<SMAccount> allCharacters = new List<SMAccount>();
 
             if (File.Exists(path))
             {
                 using (StreamReader r = new StreamReader(path))
                 {
                     string json = r.ReadToEnd();
-                    allCharacters = JsonConvert.DeserializeObject<List<SMCharacterName>>(json);
+                    allCharacters = JsonConvert.DeserializeObject<List<SMAccount>>(json);
                 }
             }
 
             // Select the name from the list
-            SMCharacterName smcn = allCharacters.FirstOrDefault(c => c.CharacterName.ToLower() == fullCharName.ToLower());
+            SMAccount smcn = allCharacters.FirstOrDefault(c => c.CharacterName.ToLower() == fullCharName.ToLower());
 
             // if the name doesn't exist...
             if (smcn == null)
             {
                 // Load the char names list into memory
                 path = FilePathSystem.GetFilePath("NPCs", "NPCNamesList");
-                List<SMCharacterName> npcCharacters = new List<SMCharacterName>();
+                List<SMAccount> npcCharacters = new List<SMAccount>();
 
                 if (File.Exists(path))
                 {
                     using (StreamReader r = new StreamReader(path))
                     {
                         string json = r.ReadToEnd();
-                        npcCharacters = JsonConvert.DeserializeObject<List<SMCharacterName>>(json);
+                        npcCharacters = JsonConvert.DeserializeObject<List<SMAccount>>(json);
                     }
                 }
 
                 // Select the name from the list
-                SMCharacterName npccn = npcCharacters.FirstOrDefault(c => c.CharacterName.ToLower() == fullCharName.ToLower());
+                SMAccount npccn = npcCharacters.FirstOrDefault(c => c.CharacterName.ToLower() == fullCharName.ToLower());
 
                 if (npccn == null)
                 {
@@ -84,7 +87,7 @@ namespace SlackMUDRPG.CommandClasses
             }
             else 
             {
-                return false; // .. the name can't be used as a player has used it.
+                return false; // .. the name can't be used
             }
         }
 
@@ -97,19 +100,19 @@ namespace SlackMUDRPG.CommandClasses
         {
             // Load the char names list into memory
             string path = FilePathSystem.GetFilePath("Characters", "CharNamesList");
-            List<SMCharacterName> allCharacters = new List<SMCharacterName>();
+            List<SMAccount> allCharacters = new List<SMAccount>();
 
             if (File.Exists(path))
             {
                 using (StreamReader r = new StreamReader(path))
                 {
                     string json = r.ReadToEnd();
-                    allCharacters = JsonConvert.DeserializeObject<List<SMCharacterName>>(json);
+                    allCharacters = JsonConvert.DeserializeObject<List<SMAccount>>(json);
                 }
             }
 
             // Create a new character reference
-            SMCharacterName smcn = new SMCharacterName();
+            SMAccount smcn = new SMAccount();
             smcn.CharacterName = fullCharName;
             smcn.AccountReference = accountReference;
 
@@ -123,6 +126,111 @@ namespace SlackMUDRPG.CommandClasses
             {
                 w.WriteLine(listJSON);
             }
+        }
+
+        /// <summary>
+        /// Update the user details of the character to the character names file
+        /// This provides easy reference to the username / password when logging in
+        /// on other platforms.
+        /// </summary>
+        /// <param name="smc">The character being used</param>
+        public void UpdateUserDetails(SMCharacter smc)
+        {
+            // Load the char names list into memory
+            string path = FilePathSystem.GetFilePath("Characters", "CharNamesList");
+            List<SMAccount> allCharacters = new List<SMAccount>();
+
+            if (File.Exists(path))
+            {
+                using (StreamReader r = new StreamReader(path))
+                {
+                    string json = r.ReadToEnd();
+                    allCharacters = JsonConvert.DeserializeObject<List<SMAccount>>(json);
+                }
+            }
+
+            // Find the relevant one
+            SMAccount smcn = allCharacters.FirstOrDefault(c => c.CharacterName.ToLower() == smc.GetFullName().ToLower());
+
+            // remove the existing one from the memory
+            allCharacters.Remove(smcn);
+
+            // Check if we found something, if we didn't we might have an issue..
+            if (smcn != null)
+            {
+                smcn.EmailAddress = smc.Username;
+                smcn.HashedPassword = smc.Password;
+            }
+
+            // Now save that back out.
+            allCharacters.Add(smcn);
+
+            if (File.Exists(path))
+            {
+                using (StreamReader r = new StreamReader(path))
+                {
+                    string json = r.ReadToEnd();
+                    allCharacters = JsonConvert.DeserializeObject<List<SMAccount>>(json);
+                }
+            }
+        }
+
+        public string LogIn(string usernameIn, string passwordIn, string connectionAddress)
+        {
+            // Load the char names list into memory
+            string path = FilePathSystem.GetFilePath("Characters", "CharNamesList");
+            List<SMAccount> allCharacters = new List<SMAccount>();
+
+            if (File.Exists(path))
+            {
+                using (StreamReader r = new StreamReader(path))
+                {
+                    string json = r.ReadToEnd();
+                    allCharacters = JsonConvert.DeserializeObject<List<SMAccount>>(json);
+                }
+            }
+
+            // Find the relevant one
+            SMAccount smcn = allCharacters.FirstOrDefault(c => ((c.EmailAddress == usernameIn) && (c.HashedPassword == Utility.Crypto.DecryptStringAES(passwordIn, "ProvinceMud"))));
+
+            // Check if we've found an account
+            if (smcn != null)
+            {
+                // Check if the current connection address is the account reference,
+                // if not add it to the list so we can check when connecting so we 
+                // can load the correct account in without the username / password
+                // being needed each time.
+                if (connectionAddress != smcn.AccountReference)
+                {
+                    // remove the current char reference from the file
+                    allCharacters.Remove(smcn);
+
+                    // create a new char reference element.
+                    SMAccountOtherReference smaor = new SMAccountOtherReference();
+                    smaor.OtherReference = smcn.AccountReference;
+
+                    // Add the character back to the list with the new reference
+                    allCharacters.Add(smcn);
+
+                    // Save the file back to the disk
+                    string listJSON = JsonConvert.SerializeObject(allCharacters, Formatting.Indented);
+
+                    using (StreamWriter w = new StreamWriter(path))
+                    {
+                        w.WriteLine(listJSON);
+                    }
+                }
+
+                // return the main account reference
+                return smcn.AccountReference;
+            }
+            else 
+            {
+                // return nothing
+                return "";
+            }
+
+            
         }
     }
 }

--- a/SlackMUDRPG/CommandClasses/SMCharacter.cs
+++ b/SlackMUDRPG/CommandClasses/SMCharacter.cs
@@ -640,6 +640,28 @@ namespace SlackMUDRPG.CommandClasses
 			this.sendMessageToPlayer(whoOnlineString);
 		}
 
+        /// <summary>
+        /// Updates the password for the character
+        /// </summary>
+        /// <param name="newPassword">The new password</param>
+        public void SetPassword(string newPassword)
+        {
+            this.Password = Utility.Crypto.EncryptStringAES(newPassword, "ProvinceMud");
+            this.SaveToApplication();
+            this.SaveToFile();
+            this.sendMessageToPlayer("[i]Password updated[/i]");
+        }
+
+        /// <summary>
+        /// Sets the username to be different if needed.
+        /// </summary>
+        /// <param name="newUserName">The new username to use</param>
+        public void SetUserName(string newUserName)
+        {
+            this.Username = newUserName;
+            this.sendMessageToPlayer("[i]Username updated[/i]");
+        }
+
 		#endregion
 
 		#region "Skill Related Items"

--- a/SlackMUDRPG/JSON/Characters/Chard55f4db9-5c36-430e-a91a-97160e88d4f1.json
+++ b/SlackMUDRPG/JSON/Characters/Chard55f4db9-5c36-430e-a91a-97160e88d4f1.json
@@ -1,14 +1,14 @@
 {
   "firstname": "Bert",
   "lastname": "Jay",
-  "lastinteractiondate": "2017-04-16T15:40:29.5934793+01:00",
-  "lastlogindate": "2017-04-16T15:39:30.2971218+01:00",
+  "lastinteractiondate": "2017-04-16T15:58:48.9716065+01:00",
+  "lastlogindate": "2017-04-16T15:58:32.9487021+01:00",
   "age": 18,
   "sex": "m",
   "pkFlag": false,
   "userID": "d55f4db9-5c36-430e-a91a-97160e88d4f1",
-  "username": "aa",
-  "password": "EAAAAGiOAnVYoX8Sv9HlF0fU9rWyeuILro0V09AfzbyWk5Ei",
+  "username": "Paul",
+  "password": "EAAAAAUGGDWIrDWGNVFjfQ872Le+lblLslXN9p24c4XDkQXl",
   "roomID": "Ravensmere.Harbour South.Docklands Way South",
   "newbieTipsDisabled": false,
   "questLog": [
@@ -121,6 +121,6 @@
   "characterWeight": 50,
   "characterSize": 160,
   "connectionService": "WS",
-  "lastUsedCommand": "move DWS",
+  "lastUsedCommand": "setpassword paul101",
   "variableResponse": "m"
 }

--- a/SlackMUDRPG/JSON/Commands/Commands.General.json
+++ b/SlackMUDRPG/JSON/Commands/Commands.General.json
@@ -90,17 +90,43 @@
 		"ExampleUsage": "{name|lower}",
 		"RequiredSkill": null
 	},
-	{
+	//{
+	//	"CommandFamily": "General",
+	//	"CommandName": "flush",
+	//	"CommandDescription": "Flush the character from menu and set them at the start location.",
+	//	"CommandSyntax": "flush",
+	//	"ParamsExpression": null,
+	//	"CommandClass": "SlackMUDRPG.CommandClasses.SMCharacter",
+	//	"CommandMethod": "Flush",
+	//	"PassCommandAsFirstArg": false,
+	//	"PassUserIDAsFirstArg": false,
+	//	"ExampleUsage": "flush",
+	//	"RequiredSkill": null
+	//},
+  {
+    "CommandFamily": "General",
+    "CommandName": "setpassword",
+    "CommandDescription": "Sets a new password for the character.",
+    "CommandSyntax": "setpassword <whatever-you-want>",
+    "ParamsExpression": "{.+}",
+    "CommandClass": "SlackMUDRPG.CommandClasses.SMCharacter",
+    "CommandMethod": "SetPassword",
+    "PassCommandAsFirstArg": false,
+    "PassUserIDAsFirstArg": false,
+    "ExampleUsage": "setpassword 12345678",
+    "RequiredSkill": null
+  },
+  {
 		"CommandFamily": "General",
-		"CommandName": "flush",
-		"CommandDescription": "Flush the character from menu and set them at the start location.",
-		"CommandSyntax": "flush",
-		"ParamsExpression": null,
+		"CommandName": "setusername",
+		"CommandDescription": "Sets a new username for the character.",
+		"CommandSyntax": "setusername <whatever-you-want>",
+		"ParamsExpression": "{.+}",
 		"CommandClass": "SlackMUDRPG.CommandClasses.SMCharacter",
-		"CommandMethod": "Flush",
+		"CommandMethod": "SetUserName",
 		"PassCommandAsFirstArg": false,
 		"PassUserIDAsFirstArg": false,
-		"ExampleUsage": "flush",
+		"ExampleUsage": "setusername paul@paul.com",
 		"RequiredSkill": null
 	}
 ]


### PR DESCRIPTION
…ir characters.

Two new commands created:
setusername <whatever>
setpassword <whatever>
Restructure the SMAccount information to be more practical for future use.
Created a login command in the account area.
The login command will also check the connection address (i.e. slack id, skype id, webcookie, etc) - if it find it's different from the main account reference it will add it to the "other reference" list.  This means that next time the user connects from the service they're using we will be able to just play rather than having to log in again.