### PR TITLE
- Created a new quest line from Mr Zog - A Test Of Power.

### DIFF
--- a/SlackMUDRPG/CommandClasses/SMCharacter.cs
+++ b/SlackMUDRPG/CommandClasses/SMCharacter.cs
@@ -793,13 +793,23 @@ namespace SlackMUDRPG.CommandClasses
 			    else
 			    {
 				    // Can't use the skill so let the player know!
-				    this.sendMessageToPlayer(this.Formatter.General($"You need to learn the \"{skillName}\" skill before you can use it."));
+				    this.sendMessageToPlayer(this.Formatter.Italic($"You need to learn the \"{skillName}\" skill before you can use it."));
 			    }
             }
             else
             {
                 this.sendMessageToPlayer(this.Formatter.Italic($"You are already {this.CurrentActivity}"));
             }
+        }
+
+        /// <summary>
+        /// Cast a spell
+        /// </summary>
+        /// <param name="spellName">The name of the spell being cast</param>
+        /// <param name="targetName">The target name if any</param>
+        public void Cast(string spellName, string targetName = null)
+        {
+            UseSkill(spellName, targetName);
         }
 
 		/// <summary>

--- a/SlackMUDRPG/CommandClasses/SMNPC.cs
+++ b/SlackMUDRPG/CommandClasses/SMNPC.cs
@@ -590,6 +590,31 @@ namespace SlackMUDRPG.CommandClasses
                         ProcessConversationStep(npcc, nextStepsStartConversation[1], smcStartConversation);
 
                         break;
+                    case "checkskilllevel":
+                        // Find the name of the person we want to start a conversation with
+                        // and the conversation we're going to go to.
+                        string[] nextStepsCheckSkillLevel = npccs.AdditionalData.Split('|');
+                        string nextStepCheckSkillLevel = nextStepsCheckSkillLevel[2];
+
+
+                        // Get the character skill level for the specificed skill.
+                        // Check if the player already has the skill
+                        if (invokingCharacter.Skills == null)
+                        {
+                            nextStepCheckSkillLevel = nextStepsCheckSkillLevel[3];
+                        }
+                        else
+                        {
+                            if (invokingCharacter.Skills.Count(skill => ((skill.SkillName == nextStepsCheckSkillLevel[0])&&(skill.SkillLevel.ToString() == nextStepsCheckSkillLevel[1]))) == 0)
+                            {
+                                nextStepCheckSkillLevel = nextStepsCheckSkillLevel[3];
+                            }
+                        }
+                        
+                        // Process the conversation.
+                        ProcessConversationStep(npcc, nextStepCheckSkillLevel, invokingCharacter);
+                        
+                        break;
                     case "wait":
                         System.Threading.Thread.Sleep(int.Parse(npccs.AdditionalData) * 1000);
                         break;

--- a/SlackMUDRPG/JSON/Characters/Chara99353f5-1afc-41ae-a629-9510e08f514a.json
+++ b/SlackMUDRPG/JSON/Characters/Chara99353f5-1afc-41ae-a629-9510e08f514a.json
@@ -1,15 +1,15 @@
 {
   "firstname": "Io",
   "lastname": "Rn",
-  "lastinteractiondate": "2017-04-17T15:52:35.8369932+01:00",
-  "lastlogindate": "2017-04-17T15:52:32.0748075+01:00",
+  "lastinteractiondate": "2017-04-17T17:16:25.9063688+01:00",
+  "lastlogindate": "2017-04-17T17:20:06.4212191+01:00",
   "age": 18,
   "sex": "m",
   "pkFlag": false,
   "userID": "a99353f5-1afc-41ae-a629-9510e08f514a",
   "username": "aa",
   "password": "EAAAAKUvuavRbXLzy6KA4tOYzycTs2ROEiG6dbmeNCsmEKSo",
-  "roomID": "Ravensmere.Military District.Battle Coordinators Office",
+  "roomID": "Ravensmere.Military District.Sparring Area",
   "newbieTipsDisabled": false,
   "questLog": [
     {
@@ -121,7 +121,6 @@
   "characterWeight": 50,
   "characterSize": 160,
   "connectionService": "WS",
-  "lastUsedCommand": "resp N",
-  "variableResponse": "Yon Death",
-  "npCsWaitingForResponses": []
+  "lastUsedCommand": "cast fly wooden chest",
+  "variableResponse": "Yon Death"
 }

--- a/SlackMUDRPG/JSON/Commands/Commands.Skill.json
+++ b/SlackMUDRPG/JSON/Commands/Commands.Skill.json
@@ -24,5 +24,18 @@
 		"PassUserIDAsFirstArg": false,
 		"ExampleUsage": "build Wooden Hut",
 		"RequiredSkill": null
+	},
+	{
+		"CommandFamily": "Skill",
+		"CommandName": "cast",
+		"CommandDescription": "Enables the player to cast a spell.",
+		"CommandSyntax": "cast <Name Of Spell> <Optional Target>",
+		"ParamsExpression": "{.+} {.+}?",
+		"CommandClass": "SlackMUDRPG.CommandClasses.SMCharacter",
+		"CommandMethod": "Cast",
+		"PassCommandAsFirstArg": false,
+		"PassUserIDAsFirstArg": false,
+		"ExampleUsage": "cast fly stick, or cast thunderbolt",
+		"RequiredSkill": null
 	}
 ]

--- a/SlackMUDRPG/JSON/NPCs/Mr Zog.json
+++ b/SlackMUDRPG/JSON/NPCs/Mr Zog.json
@@ -154,7 +154,53 @@
               "ResponseOptionActionSteps": [
                 {
                   "NPCResponseOptionActionType": "Conversation",
-                  "AdditionalData": "LookingForWork.1"
+                  "AdditionalData": "LookingForWork.1",
+                  "PreRequisites": [
+                    {
+                      "Type": "HasNotDoneQuest",
+                      "AdditionalData": "The Root Of The Problem"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "ResponseOptionShortcut": "Magic",
+              "ResponseOptionText": "Is this magic stuff something I could learn?",
+              "ResponseOptionActionSteps": [
+                {
+                  "NPCResponseOptionActionType": "Conversation",
+                  "AdditionalData": "ATestOfPower.1",
+                  "PreRequisites": [
+                    {
+                      "Type": "HasNotDoneQuest",
+                      "AdditionalData": "A Test Of Power"
+                    },
+                    {
+                      "Type": "IsNotInProgressQuest",
+                      "AdditionalData": "A Test Of Power"
+                    },
+                    {
+                      "Type": "HasDoneQuest",
+                      "AdditionalData": "The Root Of The Problem"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "ResponseOptionShortcut": "Test",
+              "ResponseOptionText": "I feel I'm ready for you to test me",
+              "ResponseOptionActionSteps": [
+                {
+                  "NPCResponseOptionActionType": "Conversation",
+                  "AdditionalData": "ATestOfPower.Test",
+                  "PreRequisites": [
+                    {
+                      "Type": "IsInProgressQuest",
+                      "AdditionalData": "A Test Of Power"
+                    }
+                  ]
                 }
               ]
             },
@@ -476,6 +522,179 @@
           "StepID": "4",
           "Scope": "updatequest",
           "AdditionalData": "Zog.The Root Of The Problem",
+          "NextStep": "5.0",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "5",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Is there anything else I can do for you today?",
+          "NextStep": null,
+          "ResponseOptions": [
+            {
+              "ResponseOptionShortcut": "Magic",
+              "ResponseOptionText": "Is this magic stuff something I could learn?",
+              "ResponseOptionActionSteps": [
+                {
+                  "NPCResponseOptionActionType": "Conversation",
+                  "AdditionalData": "ATestOfPower.1"
+                }
+              ]
+            },
+            {
+              "ResponseOptionShortcut": "N",
+              "ResponseOptionText": "No",
+              "ResponseOptionActionSteps": [
+                {
+                  "NPCResponseOptionActionType": "Conversation",
+                  "AdditionalData": "RootOfTheProblem.End"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "StepID": "End",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Very well, please come back tomorrow if you want to earn some more money... I may have some more jobs then.",
+          "NextStep": null,
+          "ResponseOptions": null
+        }
+      ]
+    },
+    {
+      "ConversationID": "ATestOfPower",
+      "ConversationStep": [
+        {
+          "StepID": "1",
+          "Scope": "emotetoplayer",
+          "AdditionalData": "Zog coughs into his hand sending sparks shooting out of his ears. His eyes seem to twinkle as it examines you.",
+          "NextStep": "2.1",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "2",
+          "Scope": "saytoplayer",
+          "AdditionalData": "One might try for years to master the arcane arts and not even be able to summon a drop of water but, there are some, like myself, who have the inate talent in our blood.",
+          "NextStep": "3.1",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "3",
+          "Scope": "emotetoplayer",
+          "AdditionalData": "concentrates and then the shops light starts to wane and his skin seems to glow gently with a golden gleem.",
+          "NextStep": "4.1",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "4",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Awakening this talent is difficult and often unrewarding.  However I can see potential in you.  Yes.  Yes I can!  Much potential. ",
+          "NextStep": "5.1",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "5",
+          "Scope": "emotetoplayer",
+          "AdditionalData": "hands you a small pouch.",
+          "NextStep": "6.1",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "6",
+          "Scope": "giveitem",
+          "AdditionalData": "QuestItem.ZogsPouch,1",
+          "NextStep": "7.3",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "7",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Within that pouch lies a runestone. The stone is imbued with concentrated magic allowing a none magi such as yourself to be able to manipulate it without channeling your own magical stores into it.",
+          "NextStep": "8.3",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "8",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Take it away with you, read the instructions inside and make the runestone hover but an inch above your hand and I will talk to you further.",
+          "NextStep": "9.3",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "9",
+          "Scope": "emotetoplayer",
+          "AdditionalData": "relaxes a little and the light in the shop returns to normal.",
+          "NextStep": "10.1",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "10",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Make that cube fly and then perhaps, I will show you a thing or two.",
+          "NextStep": "11.0",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "11",
+          "Scope": "addquest",
+          "AdditionalData": "Zog.A Test Of Power",
+          "NextStep": "12.0",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "12",
+          "Scope": "teachskill",
+          "AdditionalData": "Fly.1",
+          "NextStep": null,
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "Test",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Hrm, is that so...",
+          "NextStep": "Test2.2",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "Test2",
+          "Scope": "emotetoplayer",
+          "AdditionalData": "concentrates on {playercharacter}...",
+          "NextStep": "Test3.2",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "Test3",
+          "Scope": "checkskilllevel",
+          "AdditionalData": "Fly|10|TestPass|TestFail",
+          "NextStep": "Test2.2",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "TestPass",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Ah - yes, I can see it in your aura, you [b]do[/b] have power...",
+          "NextStep": "TestPass2",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "TestPass2",
+          "Scope": "updatequest",
+          "AdditionalData": "Zog.A Test Of Power",
+          "NextStep": "TestPass3.0",
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "TestPass3",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Here, take this book - it contains some other spells for you to try...",
+          "NextStep": null,
+          "ResponseOptions": null
+        },
+        {
+          "StepID": "TestFail",
+          "Scope": "saytoplayer",
+          "AdditionalData": "Hrm, you're not quite skilled enough yet... come back when you've practiced some more...",
           "NextStep": null,
           "ResponseOptions": null
         }

--- a/SlackMUDRPG/JSON/Objects/Book.AMagistasCompanion.json
+++ b/SlackMUDRPG/JSON/Objects/Book.AMagistasCompanion.json
@@ -1,0 +1,16 @@
+﻿{
+	"SingularPronoun": "a",
+	"ItemName": "book entitled \"A Magistas Companion\"",
+	"PluralPronoun": "some",
+	"PluralName": "books entitled \"A Magistas Companion\"",
+	"ItemType": "Readable",
+	"ItemFamily": "Book",
+	"ItemDescription": "This worn tome looks to have been well used",
+	"ItemExtraDetail": "SpellsSpellsSpells... all you need to know about spells",
+	"ItemWeight": 1,
+	"ItemSize": 1,
+	"HitPoints": 1000000000,
+	"MaxHitPoints": 1000000000,
+	"BaseDamage": 0.001,
+	"Toughness": 50
+}

--- a/SlackMUDRPG/JSON/Objects/Quest.ZogsPouch.json
+++ b/SlackMUDRPG/JSON/Objects/Quest.ZogsPouch.json
@@ -1,0 +1,52 @@
+﻿{
+  "itemID": "Generate",
+  "SingularPronoun": "a",
+  "ItemName": "Small Pouch",
+  "PluralPronoun": "some",
+  "PluralName": "Small Pouches",
+  "ItemType": "Container",
+  "ItemFamily": "Pouch",
+  "ItemDescription": "This is a book",
+  "ItemExtraDetail": "This is the content of the book...",
+  "ItemWeight": 0,
+  "ItemSize": 0,
+  "HitPoints": 1000000000,
+  "MaxHitPoints": 1000000000,
+  "BaseDamage": 0.001,
+  "Toughness": 1,
+  "HeldItem": [
+    {
+      "itemID": "Generate",
+      "SingularPronoun": "a",
+      "ItemName": "Small Purple Runestone",
+      "PluralPronoun": "some",
+      "PluralName": "Small Purple Runestones",
+      "ItemType": "Container",
+      "ItemFamily": "Pouch",
+      "ItemDescription": "Small Purple Runestone covered in strange markings.",
+      "ItemWeight": 0,
+      "ItemSize": 0,
+      "HitPoints": 1000000000,
+      "MaxHitPoints": 1000000000,
+      "BaseDamage": 0.001,
+      "Toughness": 1
+    },
+    {
+      "itemID": "Generate",
+      "SingularPronoun": "a",
+      "ItemName": "small note",
+      "PluralPronoun": "some",
+      "PluralName": "small notes",
+      "ItemType": "Readable",
+      "ItemFamily": "Note",
+      "ItemDescription": "A slip of paper with some writing on it.",
+      "ItemExtraDetail": "I am a runestone, that will out you to the test.  Cast your intent upon me and I shall do the rest... [i]To practice with the runestone use the command \"cast fly runestone\"[/i]",
+      "ItemWeight": 1,
+      "ItemSize": 1,
+      "HitPoints": 1000000000,
+      "MaxHitPoints": 1000000000,
+      "BaseDamage": 0.001,
+      "Toughness": 50
+    }
+  ]
+}

--- a/SlackMUDRPG/JSON/Objects/Quest.ZogsRuneStone.json
+++ b/SlackMUDRPG/JSON/Objects/Quest.ZogsRuneStone.json
@@ -1,0 +1,15 @@
+﻿{
+	"SingularPronoun": "a",
+	"ItemName": "Small Purple Runestone",
+	"PluralPronoun": "some",
+	"PluralName": "Small Purple Runestones",
+	"ItemType": "Container",
+	"ItemFamily": "Pouch",
+	"ItemDescription": "Small Purple Runestone covered in strange markings.",
+	"ItemWeight": 0,
+	"ItemSize": 0,
+	"HitPoints": 1000000000,
+	"MaxHitPoints": 1000000000,
+	"BaseDamage": 0.001,
+  "Toughness": 1
+}

--- a/SlackMUDRPG/JSON/Quests/Zog.A Test Of Power.json
+++ b/SlackMUDRPG/JSON/Quests/Zog.A Test Of Power.json
@@ -1,0 +1,21 @@
+﻿{
+	"QuestName": "A Test Of Power",
+	"Prerequisites": null,
+	"Daily": true,
+	"QuestSteps": [
+		{
+			"Name": "Levitate a runestone",
+			"Type": "SkillTest",
+			"CharacterName": "Mr Zog",
+			"LocationID": "Ravensmere.Harbour South.Zogs Arcanum",
+			"AdditionalData": "Levitate",
+			"Instructions": "Demonstrate that you can levitate a runestone to Mr Zog"
+		}
+	],
+	"Rewards": [
+		{
+			"Type": "Object",
+			"AdditionalData": "Book.AMagistasCompanion,1"
+		}
+	]
+}

--- a/SlackMUDRPG/JSON/Skills/Skill.Cast-Fly.json
+++ b/SlackMUDRPG/JSON/Skills/Skill.Cast-Fly.json
@@ -1,0 +1,74 @@
+{
+  "SkillType": {
+    "SkillTypeName": "Magic",
+    "SkillTypeDescription": "A skill only usable by people trained in the arcane arts"
+  },
+  "SkillName": "Fly",
+	"CanUseWithoutLearning":  false,
+  "SkillDescription": "The ability to make something fly.",
+  "SkillLearnText": "You've learnt how to make something fly.",
+  "LevelIncreaseText":  "You feel you've gotten better at making things fly.",
+  "ActivityType":  "Casting",
+  "BaseStat": "INT",
+  "LevelMultiplier": 10,
+  "ImprovementSpeed": 10,
+  "Prerequisites": [
+    {
+      "IsSkill": false,
+      "SkillStatName": "INT",
+      "PreReqLevel": 10
+    }
+  ],
+  "SkillSteps": [
+    {
+      "StepType": "Target",
+      "StepRequiredObject": null,
+      "RequiredObjectAmount": 1,
+      "FailureOutput": "You must target something",
+      "SuccessOutput": null
+    },
+    {
+      "StepType": "Information",
+      "StepRequiredObject": null,
+      "RequiredObjectAmount": 0,
+      "FailureOutput": null,
+      "SuccessOutput": "{CHARNAME} concentrates and focuses on {TARGETNAME}"
+    },
+    {
+      "StepType": "Pause",
+      "StepRequiredObject": null,
+      "RequiredObjectAmount": 5,
+      "FailureOutput": null,
+      "SuccessOutput": null
+    },
+    {
+      "StepType": "Information",
+      "StepRequiredObject": null,
+      "RequiredObjectAmount": 0,
+      "FailureOutput": null,
+      "SuccessOutput": "The {TARGETNAME} begins to wobble a little"
+    },
+    {
+      "StepType": "Pause",
+      "StepRequiredObject": null,
+      "RequiredObjectAmount": 5,
+      "FailureOutput": null,
+      "SuccessOutput": null
+    },
+    {
+      "StepType": "Cast",
+      "StepRequiredObject": null,
+      "RequiredObjectAmount": 0,
+      "ExtraData": "Fly",
+      "FailureOutput": "The {TARGETNAME} stops wobbling",
+      "SuccessOutput": "The {TARGETNAME} flys up"
+    },
+    {
+      "StepType": "Repeat",
+      "StepRequiredObject": "Activity.Casting",
+      "RequiredObjectAmount": 0,
+      "FailureOutput": null,
+      "SuccessOutput": null
+    }
+  ]	
+}

--- a/SlackMUDRPG/SlackMUDRPG.csproj
+++ b/SlackMUDRPG/SlackMUDRPG.csproj
@@ -357,6 +357,11 @@
     <Content Include="JSON\Quests\MasterSmithDuncan.The Magic Of Metal.json" />
     <Content Include="JSON\Objects\Weapons.PracticeBlacksmithHammer.json" />
     <Content Include="JSON\Objects\Tools.PracticeTongs.json" />
+    <Content Include="JSON\Quests\Zog.A Test Of Power.json" />
+    <Content Include="JSON\Objects\Book.AMagistasCompanion.json" />
+    <Content Include="JSON\Objects\Quest.ZogsPouch.json" />
+    <Content Include="JSON\Objects\Quest.ZogsRuneStone.json" />
+    <Content Include="JSON\Skills\Skill.Cast-Fly.json" />
     <None Include="scripts\jquery-3.1.1.intellisense.js" />
     <Content Include="scripts\ai.1.0.7-build00691.js" />
     <Content Include="scripts\ai.1.0.7-build00691.min.js" />


### PR DESCRIPTION
- NPCs can now test the level of a characters skill using the "checkskilllevel" switch in a conversation.
- Added new type of skill "spells" for casting things - along with a new "cast" command, used like: cast <name of spell> <optional target>
- Created a few new object for the quest to be handed over:
> The pouch with runestone and note in it.
> A book for the completion benefit.
- Updated the conversations for Mr Zog to include the new quests.  You have to reach level 10 in the skill for Mr Zog to approve of your skill.
- Created a new "Fly" skill - you have to be taught it, but from then on you can use it.