### PR TITLE
Command History Navigation

### DIFF
--- a/SlackMUDRPG/scripts/slackmud_gamepage_websockets.js
+++ b/SlackMUDRPG/scripts/slackmud_gamepage_websockets.js
@@ -4,7 +4,9 @@
 		protocol = location.protocol === "https:" ? "s" : "",
 		gameInput = $("#game-input"),
 		gameOutput = $("#game-output"),
-		submitCmdBtn = $("#submit-cmd");
+		submitCmdBtn = $("#submit-cmd"),
+		usedCommands = [],
+		usedCommandPointer = null;
 
 	if (userid !== null) {
 		console.log("Cookie:" + userid);
@@ -21,6 +23,16 @@
 				sendMessage();
 				scrollToBottom();
 			});
+
+			gameInput.on("keyup", function gameInputMouseup(e) {
+				if (e.keyCode == 38 || e.keyCode == 40) {
+					e.preventDefault();
+					handleUpDownArrows(e.keyCode);
+				} else {
+					usedCommandPointer = null;
+				}
+			});
+
 			enableInput();
 		};
 
@@ -64,8 +76,11 @@
 	};
 
 	function sendMessage() {
-		if (gameInput.val() != '') {
-			ws.send(gameInput.val());
+		var val = gameInput.val();
+
+		if (val != '') {
+			addToStack(usedCommands, val);
+			ws.send(val);
 			gameInput.val('');
 		}
 	};
@@ -91,4 +106,46 @@
 			return false;
 		};
 	});
+
+	function addToStack(stack, value) {
+		if (stack.length >= 50) {
+			stack.shift();
+		}
+
+		stack.push(value);
+	}
+
+	function getFromStack(stack, index) {
+
+		if (typeof stack[index] === "undefined") {
+			return null;
+		}
+
+		return stack[index];
+	}
+
+	function handleUpDownArrows(keyCode) {
+		// 38 == up | 40 == down
+		if (usedCommands.length < 1) {
+			return;
+		}
+
+		if (usedCommandPointer == null) {
+			if (keyCode == 40) {
+				return;
+			}
+
+			usedCommandPointer = usedCommands.length - 1;
+		} else {
+			if (keyCode == 38) {
+				usedCommandPointer = usedCommandPointer-- > 0 ? usedCommandPointer : 0;
+			} else {
+				usedCommandPointer = usedCommandPointer++ < usedCommands.length - 1 ? usedCommandPointer : usedCommands.length - 1;
+			}
+		}
+
+		var newVal = getFromStack(usedCommands, usedCommandPointer)
+
+		gameInput.val(newVal);
+	}
 });


### PR DESCRIPTION
Allow users of the web version to navigate through their last 50 submitted commands using the up and down arrows.

History is maintained in the browser client side rather than server side.