### PR TITLE
- Added the ability to have echoes between zones.

### DIFF
--- a/SlackMUDRPG/CommandClasses/SMCharacter.cs
+++ b/SlackMUDRPG/CommandClasses/SMCharacter.cs
@@ -310,6 +310,20 @@ namespace SlackMUDRPG.CommandClasses
                         // If the room is not locked or the character has the right key, let them in.
                         if (initiateMove)
                         {
+                            int waitTime = 0;
+
+                            // Show echos if any are around
+                            if ((sme.Echo != null) && (sme.Echo != ""))
+                            {
+                                this.sendMessageToPlayer(sme.Echo);
+                                waitTime = 4;
+                            }
+
+                            if (waitTime > 0)
+                            {
+                                Thread.Sleep(waitTime*1000);
+                            }
+                            
                             ActualMove(smr, " walks out.", " walks in.");
                         }
                     }
@@ -357,7 +371,7 @@ namespace SlackMUDRPG.CommandClasses
                     smr.SafeZoneCharAttributes.Remove(smrsca);
                 }
             }
-
+            
             // Move the player to the new location
             this.RoomID = smr.RoomID;
             this.SaveToApplication();

--- a/SlackMUDRPG/CommandClasses/SMRoom.cs
+++ b/SlackMUDRPG/CommandClasses/SMRoom.cs
@@ -998,7 +998,10 @@ namespace SlackMUDRPG.CommandClasses
         public bool Locked { get; set; }
 
         [JsonProperty("Prerequisites")]
-        public List<SMRoomPrerequisite> Prerequisites { get; set; }        
+        public List<SMRoomPrerequisite> Prerequisites { get; set; }
+
+        [JsonProperty("Echo")]
+        public string Echo { get; set; }
     }
 
 	public class SMSpawn

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Cliffside.Marsh.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Cliffside.Marsh.json
@@ -8,13 +8,14 @@
 	"RoomExits": [
     {
 			"Shortcut": "OPT",
-			"Description": "Oldwood Plains Trail",
+			"Description": "Oldwood Plains Trail [b](Oldwood, Ravensmere City Boundary)[/b]",
 			"RoomID": "Ravensmere Boundary.Oldwood.Oldwood Plains Trail"
 		},
 		{
 			"Shortcut": "CMINE",
 			"Description": "Cliffside Mine",
-			"RoomID": "Ravensmere Boundary.Cliffside.Mine"
+      "RoomID": "Ravensmere Boundary.Cliffside.Mine",
+      "Echo": "You can just about squeeze under the collapsed lintel to make your way into the mineshaft.  The light is poor, and you must wait a few seconds for your eyes to adjust."
 		}
 	],
   "RoomItems": null,

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Cliffside.Mine Crumbling Mineshaft.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Cliffside.Mine Crumbling Mineshaft.json
@@ -9,7 +9,8 @@
     {
 			"Shortcut": "PIT",
 			"Description": "Inside the Pit",
-			"RoomID": "Ravensmere Boundary.Cliffside.Mine Pit"
+      "RoomID": "Ravensmere Boundary.Cliffside.Mine Pit",
+      "Echo": "You carefully grip the ladder and descend into the pit.  Although the rungs sag alarmingly under your feet, they have not collapsed... yet.  The wall in front of your face begins to darken as you continue your descent, the pale rock beginning to dissolve into countless strata.  It seems they finally found the ore they were looking for.  Any further thought is interrupted by an earth-shaking roar from behind you.  You spin around as your feet finally land on solid earth again."
 		},
 		{
 			"Shortcut": "ME",

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Cliffside.Mine Mineshaft Entry.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Cliffside.Mine Mineshaft Entry.json
@@ -9,7 +9,8 @@
     {
 			"Shortcut": "ME",
 			"Description": "Mine Entrance",
-			"RoomID": "Ravensmere Boundary.Cliffside.Mine"
+      "RoomID": "Ravensmere Boundary.Cliffside.Mine",
+      "Echo": "There’s finally a hint of fresh air as you approach the surface. It’s barely illuminated, but certainly better than the deeper parts of the mine, and a single lonely shaft of light seems to beckon you through the crumbled exit."
 		},
 		{
 			"Shortcut": "MS",

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Oldwood.Oldwood Plains Trail.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Oldwood.Oldwood Plains Trail.json
@@ -13,7 +13,7 @@
 		},
 		{
 			"Shortcut": "CM",
-			"Description": "Cliffside Marsh",
+			"Description": "Cliffside Marsh [b]Cliffside[/b]",
 			"RoomID": "Ravensmere Boundary.Cliffside.Marsh"
 		}
 	],

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Oldwood.Oldwood Road.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Oldwood.Oldwood Road.json
@@ -8,7 +8,7 @@
 	"RoomExits": [
     {
 			"Shortcut": "RGS",
-			"Description": "Ravensgate South",
+			"Description": "Ravensgate South [b](City Of Ravensmere)[/b]",
 			"RoomID": "Ravensmere.Industrial Quarter.Ravensgate South"
 		},
     {

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Rookdown Iron Mine.Entrance.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Rookdown Iron Mine.Entrance.json
@@ -8,7 +8,7 @@
 	"RoomExits": [
     {
       "Shortcut": "OP",
-      "Description": "Oldwood Plains",
+      "Description": "Oldwood Plains [b](Oldwood, Ravensmere Boundary)[/b]",
       "RoomID": "Ravensmere Boundary.Oldwood.Oldwood Plains"
     },
     {

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Rookdown Iron Mine.Large Crevice Light.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere Boundary.Rookdown Iron Mine.Large Crevice Light.json
@@ -7,9 +7,9 @@
   "RoomDescription": "This man sized recess looks newly excavated. Probably made for stowing smuggled goods before moving into the town.",
 	"RoomExits": [
     {
-      "Shortcut": "MP",
-      "Description": "Medium Passage",
-      "RoomID": "Ravensmere Boundary.Rookdown Iron Mine.Medium Passage"
+      "Shortcut": "GP",
+      "Description": "Glowing Passage",
+      "RoomID": "Ravensmere Boundary.Rookdown Iron Mine.Glowing Passage"
     }
 	],
   "RoomItems": [

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Bridge Row.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Bridge Row.json
@@ -13,13 +13,18 @@
 		},
 		{
 			"Shortcut": "RP",
-			"Description": "Ramparts Parade",
+			"Description": "Ramparts Parade [b](Military District)[/b]",
 			"RoomID": "Ravensmere.Military District.Ramparts Parade"
 		},
-		{
-			"Shortcut": "GCE",
-			"Description": "Greys Court East",
-			"RoomID": "Ravensmere.Town Centre.Greys Court East"
+    {
+      "Shortcut": "GCE",
+      "Description": "Greys Court East [b](Town Centre)[/b]",
+      "RoomID": "Ravensmere.Town Centre.Greys Court East"
+    },
+    {
+			"Shortcut": "DWN",
+			"Description": "Docklands Way North",
+			"RoomID": "Ravensmere.Harbour South.Docklands Way North"
 		},
 		{
 			"ShortCut": "SEB",

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Docklands Way North.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Docklands Way North.json
@@ -1,0 +1,66 @@
+{
+	"RoomID": "Ravensmere.Harbour South.Docklands Way North",
+	"RoomLocationX": "1",
+	"RoomLocationY": "1",
+	"RoomLocationZ": "1",
+  "Outside": true,
+	"RoomDescription": "Gulls call loudly from the rooftops and swoop down at the scraps left behind by fishermen. The folk here side step the many stacks of empty crates dotted around the cobbles. The sounds of the sea can be heard clearly from here.",
+	"RoomExits": [
+		{
+			"Shortcut": "DWS",
+			"Description": "Docklands Way South",
+			"RoomID": "Ravensmere.Harbour South.Docklands Way South"
+		},
+		{
+			"Shortcut": "BR",
+			"Description": "Bridge Row",
+			"RoomID": "Ravensmere.Harbour South.Bridge Row"
+		},
+    {
+      "Shortcut": "RPS",
+      "Description": "Ravensmere Promenade South",
+      "RoomID": "Ravensmere.Harbour South.Ravensmere Promenade South"
+    },
+		{
+			"Shortcut": "PAH",
+			"Description": "Princes Auction House",
+			"RoomID": "Ravensmere.Harbour South.Princes Auction House",
+      "RoomLockID": "PAHLock",
+      "Locked": true,
+      "Lockable": false
+		}
+	],
+	"RoomItems": null,
+	"NPCSpawns": [
+    {
+      "TypeOfNPC": "Guard-Generic",
+      "MaxNumber": 1,
+      "SpawnFrequency": 90,
+      "Unique": false
+    },
+    {
+      "TypeOfNPC": "Old-Sailor",
+      "MaxNumber": 1,
+      "SpawnFrequency": 90,
+      "Unique": false
+    },
+    {
+      "TypeOfNPC": "Young-Sailor",
+      "MaxNumber": 1,
+      "SpawnFrequency": 75,
+      "Unique": false
+    },
+    {
+			"TypeOfNPC": "Beggar",
+			"MaxNumber": 1,
+			"SpawnFrequency": 10,
+			"Unique": false
+		},
+    {
+      "TypeOfNPC": "Noble-Generic-Harried",
+      "MaxNumber": 1,
+      "SpawnFrequency": 10,
+      "Unique": true
+    }
+	]
+}

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Docklands Way South.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Docklands Way South.json
@@ -6,7 +6,17 @@
   "Outside": true,
 	"RoomDescription": "A long and winding street lies ahead. Buildings of varying shapes and sizes lean over from both sides to shadow the cobbles. \nThere are shops and inns dotted up and down and empty washing lines reach from window to window.\nThe street continues round a corner and there are several smaller narrow passageways to the side.",
 	"RoomExits": [
+    {
+      "Shortcut": "SL",
+      "Description": "Swabbies Lane",
+      "RoomID": "Ravensmere.Harbour South.Swabbies Lane"
+    },
 		{
+			"Shortcut": "DWN",
+			"Description": "Docklands Way North",
+			"RoomID": "Ravensmere.Harbour South.Docklands Way North"
+		},
+    {
 			"Shortcut": "AAE",
 			"Description": "Arrivals Area Entrance",
 			"RoomID": "Ravensmere.Harbour South.Arrivals Area"
@@ -15,11 +25,6 @@
 			"Shortcut": "ST",
 			"Description": "Scalebrewers Tavern",
 			"RoomID": "Ravensmere.Harbour South.Scalebrewers Tavern"
-		},
-		{
-			"Shortcut": "SL",
-			"Description": "Swabbies Lane",
-			"RoomID": "Ravensmere.Harbour South.Swabbies Lane"
 		},
     {
       "Shortcut": "RPS",

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Princes Auction House.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Princes Auction House.json
@@ -10,6 +10,11 @@
 			"Shortcut": "RPS",
 			"Description": "Ravensmere Promenade South",
 			"RoomID": "Ravensmere.Harbour South.Ravensmere Promenade South"
+		},
+		{
+			"Shortcut": "DWN",
+			"Description": "Docklands Way North",
+			"RoomID": "Ravensmere.Harbour South.Docklands Way North"
 		}
 	],
 	"RoomItems": null,

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Ravensmere Promenade South.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Ravensmere Promenade South.json
@@ -11,15 +11,23 @@
     }
   ],
 	"RoomExits": [
-		{
-			"Shortcut": "DWS",
-			"Description": "Docklands Way South",
-			"RoomID": "Ravensmere.Harbour South.Docklands Way South"
+    {
+      "Shortcut": "DWS",
+      "Description": "Docklands Way South",
+      "RoomID": "Ravensmere.Harbour South.Docklands Way South"
+    },
+    {
+			"Shortcut": "DWN",
+			"Description": "Docklands Way North",
+			"RoomID": "Ravensmere.Harbour South.Docklands Way North"
 		},
 		{
 			"Shortcut": "PAH",
 			"Description": "Princes Auction House",
-			"RoomID": "Ravensmere.Harbour South.Princes Auction House"
+			"RoomID": "Ravensmere.Harbour South.Princes Auction House",
+      "RoomLockID": "PAHLock",
+      "Locked": true,
+      "Lockable": false
 		},
 		{
 			"Shortcut": "FT",

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Industrial Quarter.Ravens South.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Industrial Quarter.Ravens South.json
@@ -8,7 +8,7 @@
 	"RoomExits": [
     {
       "Shortcut": "RP",
-      "Description": "Ramparts Parade (Road)",
+      "Description": "Ramparts Parade (Road) [b](Military District)[/b]",
       "RoomID": "Ravensmere.Military District.Ramparts Parade"
     },
     {

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Industrial Quarter.Ravensgate South.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Industrial Quarter.Ravensgate South.json
@@ -13,8 +13,9 @@
     },
     {
 			"Shortcut": "OWR",
-			"Description": "Oldwood Road",
-			"RoomID": "Ravensmere Boundary.Oldwood.Oldwood Road"
+			"Description": "Oldwood Road [b](Ravensmere Boundary)[/b]",
+      "RoomID": "Ravensmere Boundary.Oldwood.Oldwood Road",
+      "Echo": "The fresh air hits your face and you immediately notice that the stench of the city has gone."
 		}
 	],
 	"RoomItems": null,

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Grand Parade.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Grand Parade.json
@@ -6,11 +6,16 @@
   "Outside": false,
 	"RoomDescription": "Grande Parade cuts a large swathe through the military district. Young squires carry the weapons of thier masters, and messengers dash in and out of a large building surrounded by sentry guards. All who enter are searched before being allowed to proceed indoors. The harsh clatter of metal on metal can be heard coming from a stone building with outside bellows blowing air into an impressively large metal furnace.",
 	"RoomExits": [
-		{
-			"Shortcut": "RP",
-			"Description": "Ramparts Parade (Road)",
-			"RoomID": "Ravensmere.Military District.Ramparts Parade"
-		},
+    {
+      "Shortcut": "RP",
+      "Description": "Ramparts Parade (Road)",
+      "RoomID": "Ravensmere.Military District.Ramparts Parade"
+    },
+    {
+      "Shortcut": "BW",
+      "Description": "Barons Walk (Road) [b](Town Centre)[/b]",
+      "RoomID": "Ravensmere.Town Centre.Barons Walk"
+    },
 		{
 			"Shortcut": "SFT",
 			"Description": "Steelforge Blacksmiths",

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Ramparts Parade.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Military District.Ramparts Parade.json
@@ -8,7 +8,7 @@
 	"RoomExits": [
 		{
 			"Shortcut": "BR",
-			"Description": "Bridge Row (Road)",
+			"Description": "Bridge Row (Road) [b](Harbour South)[/b]",
 			"RoomID": "Ravensmere.Harbour South.Bridge Row"
 		},
 		{
@@ -28,7 +28,7 @@
 		},
 		{
 			"Shortcut": "RS",
-			"Description": "Ravens South (Road)",
+			"Description": "Ravens South (Road) [b](Industrial Quarter)[/b]",
 			"RoomID": "Ravensmere.Industrial Quarter.Ravens South"
 		}
 	],

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Town Centre.Barons Walk.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Town Centre.Barons Walk.json
@@ -8,8 +8,8 @@
 	"RoomExits": [
 		{
 			"Shortcut": "GP",
-			"Description": "Grand Parade - Military District",
-			"RoomID": "Ravensmere.Town Centre.Grand Parade"
+			"Description": "Grand Parade [b](Military District)[/b]",
+			"RoomID": "Ravensmere.Military.Grand Parade"
 		},
     {
       "Shortcut": "GS",

--- a/SlackMUDRPG/SlackMUDRPG.csproj
+++ b/SlackMUDRPG/SlackMUDRPG.csproj
@@ -396,6 +396,7 @@
     <Content Include="JSON\Locations\LocRavensmere.Town Centre.The Merchants Arms.json" />
     <Content Include="JSON\NPCs\Cassius Anor.json" />
     <Content Include="JSON\Locations\LocRavensmere.Town Centre.Merchants Arms Rooms.json" />
+    <Content Include="JSON\Locations\LocRavensmere.Harbour South.Docklands Way North.json" />
     <None Include="JSON\Objects\Consumable.SimpleArrow.json" />
     <Content Include="JSON\NPCs\Rat Catcher.json" />
     <Content Include="JSON\NPCs\Rat.json" />


### PR DESCRIPTION
- Added in an echo between the Gate to the west and the outside.
- Added in echos in the Cliffside Marsh Mine.
- Fixed the link between the Military district (Grand Parade) and the Town Center (Barons Walk).  There are now proper exits between both.
- Created Docklands Way North and linked it to DWS, BR and RPS.
- Moved the Princes Auction House to the new northern road.
- Added Rats to the cellar in the Scalebrewers Tavern.
- Added *Bold* names between zones (to really identify the exit names).