### PR TITLE
Added the Eat and Drink commands to the game.

### DIFF
--- a/SlackMUDRPG/CommandClasses/SMAttributes.cs
+++ b/SlackMUDRPG/CommandClasses/SMAttributes.cs
@@ -35,12 +35,15 @@ namespace SlackMUDRPG.CommandClasses
 		[JsonProperty("SocialStanding")]
 		public int SocialStanding { get; set; }
 
-		/// <summary>
-		/// Increases an attribute type by 1
-		/// </summary>
-		/// <param name="attributeType">The attribute type in short form</param>
-		/// <returns>The increased amount, if a 0 is returned then an error has occurred</returns>
-		public int IncreaseAttribute(string attributeType)
+        [JsonProperty("Effects")]
+        public List<SMEffect> Effects { get; set; }
+
+        /// <summary>
+        /// Increases an attribute type by 1
+        /// </summary>
+        /// <param name="attributeType">The attribute type in short form</param>
+        /// <returns>The increased amount, if a 0 is returned then an error has occurred</returns>
+        public int IncreaseAttribute(string attributeType)
 		{
 			// Set the return variable in advance
 			int updatedAttributeValue = 0;
@@ -121,27 +124,36 @@ namespace SlackMUDRPG.CommandClasses
 			switch (statShortName)
 			{
 				case ("STR"):
-					statValue = this.Strength;
+					statValue = this.EffectedStat("STR", this.Strength);
 					break;
 				case ("INT"):
-					statValue = this.Intelligence;
+					statValue = this.EffectedStat("INT", this.Intelligence);
 					break;
 				case ("CHR"):
-					statValue = this.Charisma;
+                    statValue = this.EffectedStat("CHR", this.Charisma);
 					break;
 				case ("DEX"):
-					statValue = this.Dexterity;
+                    statValue = this.EffectedStat("DEX", this.Dexterity);
 					break;
 				case ("WP"):
-					statValue = this.WillPower;
+                    statValue = this.EffectedStat("WP", this.WillPower);
 					break;
 				case ("FT"):
-					statValue = this.WillPower;
+                    statValue = this.EffectedStat("FT", this.Fortitude);
 					break;
-				case ("SS"):
-					statValue = this.SocialStanding;
-					break;
-			}
+                case ("SS"):
+                    statValue = this.EffectedStat("SS", this.SocialStanding);
+                    break;
+                case ("HP"):
+                    statValue = this.EffectedStat("HP", this.HitPoints);
+                    break;
+                case ("MAXHP"):
+                    statValue = this.EffectedStat("MAXHP", this.MaxHitPoints);
+                    break;
+                case ("T"):
+                    statValue = this.EffectedStat("T", this.GetToughness());
+                    break;
+            }
 			return statValue;
 		}
 
@@ -152,6 +164,30 @@ namespace SlackMUDRPG.CommandClasses
 			// Base Toughness based on the fortitude of someone.
 			return this.Fortitude / 10;
 		}
+
+        public int EffectedStat(string effectedStatCheck, int currentValue)
+        {
+            int modifiedStat = currentValue;
+
+            if (this.Effects != null)
+            {
+                List<SMEffect> smel = this.Effects.FindAll(e => e.EffectType.ToLower() == effectedStatCheck.ToLower());
+                if (smel != null)
+                {
+                    foreach (SMEffect sme in smel)
+                    {
+                        modifiedStat += int.Parse(sme.AdditionalData);
+                    }
+
+                    if (modifiedStat < 0)
+                    {
+                        modifiedStat = 0;
+                    }
+                }
+            }
+
+            return modifiedStat;
+        }
 
 		#endregion
 	}

--- a/SlackMUDRPG/CommandClasses/SMEffect.cs
+++ b/SlackMUDRPG/CommandClasses/SMEffect.cs
@@ -16,5 +16,8 @@ namespace SlackMUDRPG.CommandClasses
 
         [JsonProperty("AdditionalData")]
         public string AdditionalData { get; set; }
+
+        [JsonProperty("EffectLength")]
+        public int EffectLength { get; set; }
     }
 }

--- a/SlackMUDRPG/CommandClasses/SMPulse.cs
+++ b/SlackMUDRPG/CommandClasses/SMPulse.cs
@@ -167,7 +167,14 @@ namespace SlackMUDRPG.CommandClasses
             List<SMCharacter> lsmc = (List<SMCharacter>)HttpContext.Current.Application["SMCharacters"];
             foreach (SMCharacter c in lsmc.ToList())
             {
-                // ...  who're a bit hurt and logged in.
+                // Remove any attribute effects that have expired
+                if (c.Attributes.Effects != null)
+                {
+                    int currentTime = Utility.Utils.GetUnixTime();
+                    c.Attributes.Effects.RemoveAll(e => e.EffectLength <= currentTime);
+                }
+
+                // Hurt.
                 if (c.Attributes.HitPoints < c.Attributes.MaxHitPoints)
                 {
                     Random rNumber = new Random();

--- a/SlackMUDRPG/JSON/Commands/Commands.Character.json
+++ b/SlackMUDRPG/JSON/Commands/Commands.Character.json
@@ -40,15 +40,15 @@
 	},
 	{
 		"CommandFamily": "Character",
-		"CommandName": "stats",
+		"CommandName": "stats, attr, attrs, attributes, statistics, getstats",
 		"CommandDescription": "Get the statistics of your character.",
-		"CommandSyntax": "stats",
+		"CommandSyntax": "{name|lower}",
 		"ParamsExpression": null,
 		"CommandClass": "SlackMUDRPG.CommandClasses.SMCharacter",
 		"CommandMethod": "GetStats",
 		"PassCommandAsFirstArg": false,
 		"PassUserIDAsFirstArg": false,
-		"ExampleUsage": "stats",
+		"ExampleUsage": "{name|lower}",
 		"RequiredSkill": null
 	},
 	{
@@ -257,6 +257,32 @@
 		"PassCommandAsFirstArg": false,
 		"PassUserIDAsFirstArg": false,
 		"ExampleUsage": "{name|lower}",
+		"RequiredSkill": null
+	},
+	{
+		"CommandFamily": "Character",
+		"CommandName": "drink",
+		"CommandDescription": "Drinks something",
+		"CommandSyntax": "drink [item to drink]",
+		"ParamsExpression": "{.+}",
+		"CommandClass": "SlackMUDRPG.CommandClasses.SMCharacter",
+		"CommandMethod": "Drink",
+		"PassCommandAsFirstArg": false,
+		"PassUserIDAsFirstArg": false,
+		"ExampleUsage": "drink beer",
+		"RequiredSkill": null
+	},
+	{
+		"CommandFamily": "Character",
+		"CommandName": "eat",
+		"CommandDescription": "Eats something",
+		"CommandSyntax": "eat [item to eat]",
+		"ParamsExpression": "{.+}",
+		"CommandClass": "SlackMUDRPG.CommandClasses.SMCharacter",
+		"CommandMethod": "Eat",
+		"PassCommandAsFirstArg": false,
+		"PassUserIDAsFirstArg": false,
+		"ExampleUsage": "eat cheese",
 		"RequiredSkill": null
 	}
 ]

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Crabbies Smoking Den.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Crabbies Smoking Den.json
@@ -30,7 +30,17 @@
 	        "HitPoints": 1,
 	        "MaxHitPoints": 1,
 	        "BaseDamage": 0.001,
-	        "Toughness": 1
+	        "Toughness": 1,
+          "ObjectTrait": "Eatable",
+          "HeldItems": null,
+          "Effects": [
+            {
+              "Action": "OnConsume",
+              "EffectType": "MAXHP",
+              "AdditionalData": "1",
+              "EffectLength": 1200
+            }
+          ]
         },
         "AmountForSale": 0,
         "UnlimitedAvailable": true,

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Scalebrewers Tavern.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Harbour South.Scalebrewers Tavern.json
@@ -71,8 +71,25 @@
           "DestroyedOutput": null,
           "RequiredSkills": null,
           "AdditionalData": null,
-          "ObjectTrait": null,
-          "HeldItems": null
+          "ObjectTrait": "Drinkable",
+          "HeldItems": null,
+          "Effects": [
+            {
+              "Action": "OnConsume",
+              "EffectType": "Int",
+              "AdditionalData": "-1"
+            },
+            {
+              "Action": "OnConsume",
+              "EffectType": "Chr",
+              "AdditionalData": "1"
+            },
+            {
+              "Action": "OnConsume",
+              "EffectType": "Dex",
+              "AdditionalData": "-2"
+            }
+          ]
         },
         "AmountForSale": 0,
         "UnlimitedAvailable": true,
@@ -99,8 +116,28 @@
           "DestroyedOutput": null,
           "RequiredSkills": null,
           "AdditionalData": null,
-          "ObjectTrait": null,
-          "HeldItems": null
+          "ObjectTrait": "Drinkable",
+          "HeldItems": null,
+          "Effects": [
+            {
+              "Action": "OnConsume",
+              "EffectType": "Int",
+              "AdditionalData": "-1",
+              "EffectLength": 300
+            },
+            {
+              "Action": "OnConsume",
+              "EffectType": "Chr",
+              "AdditionalData": "1",
+              "EffectLength": 150
+            },
+            {
+              "Action": "OnConsume",
+              "EffectType": "Dex",
+              "AdditionalData": "-2",
+              "EffectLength": 300
+            }
+          ]
         },
         "AmountForSale": 0,
         "UnlimitedAvailable": true,

--- a/SlackMUDRPG/JSON/Locations/LocRavensmere.Town Centre.The Merchants Arms.json
+++ b/SlackMUDRPG/JSON/Locations/LocRavensmere.Town Centre.The Merchants Arms.json
@@ -42,8 +42,28 @@
           "DestroyedOutput": null,
           "RequiredSkills": null,
           "AdditionalData": null,
-          "ObjectTrait": null,
-          "HeldItems": null
+          "ObjectTrait": "Drinkable",
+          "HeldItems": null,
+          "Effects": [
+            {
+              "Action": "OnConsume",
+              "EffectType": "Int",
+              "AdditionalData": "-1",
+              "EffectLength": 300
+            },
+            {
+              "Action": "OnConsume",
+              "EffectType": "Chr",
+              "AdditionalData": "1",
+              "EffectLength": 150
+            },
+            {
+              "Action": "OnConsume",
+              "EffectType": "Dex",
+              "AdditionalData": "-2",
+              "EffectLength": 300
+            }
+          ]
         },
         "AmountForSale": 0,
         "UnlimitedAvailable": true,
@@ -70,8 +90,28 @@
           "DestroyedOutput": null,
           "RequiredSkills": null,
           "AdditionalData": null,
-          "ObjectTrait": null,
-          "HeldItems": null
+          "ObjectTrait": "Drinkable",
+          "HeldItems": null,
+          "Effects": [
+            {
+              "Action": "OnConsume",
+              "EffectType": "Int",
+              "AdditionalData": "-1",
+              "EffectLength": 300
+            },
+            {
+              "Action": "OnConsume",
+              "EffectType": "Chr",
+              "AdditionalData": "1",
+              "EffectLength": 150
+            },
+            {
+              "Action": "OnConsume",
+              "EffectType": "Dex",
+              "AdditionalData": "-2",
+              "EffectLength": 300
+            }
+          ]
         },
         "AmountForSale": 0,
         "UnlimitedAvailable": true,


### PR DESCRIPTION
Characters can now consume things that have one of two traits:
> Eatable
> Drinkable
Items are removed from the character when used.
Effects can now be applied agains the character attributes.
Updated the stats system to take into account effects.
Updated the SMEffect class to have a length of effect.
Updated the beers in the Scalebrewers Tavern and the Merchants Arms to be drinkable - they also effect the following stats when drunk:
> Int (-1)
> Chr (1)
> Dex (-2)
This effect is stackable.
Updated the Smoked Fish in the Fish Shack to give an increase to the max HP (+1) for 20 mins (also stackable).
Updated the "Stats" command to also have the following aliases "attr, attrs, attributes, statistics, getstats"