### PR TITLE
Improve inventory (i) command

### DIFF
--- a/SlackMUDRPG/CommandClasses/SMCharacter.cs
+++ b/SlackMUDRPG/CommandClasses/SMCharacter.cs
@@ -2378,6 +2378,15 @@ namespace SlackMUDRPG.CommandClasses
 			}
 			else
 			{
+				// If the given slot name is actually the name of the item equipped to the slot
+				// then examine the item rather than listing inventory
+				if (this.GetEquippedItem(slotName) != null)
+				{
+					this.InspectObject(slotName);
+					return;
+				}
+
+				// List slot inventory
 				inventory += this.ListSlotDetails(slotName, true);
 			}
 


### PR DESCRIPTION
- Update inventory (i) command to allow the user to get information about the item equipped to a slot using the items names rather than the slots name. For example if you have a quiver in your right hand you can use `i right hand` or `i quiver` to get info about the quiver.