### PR TITLE
Missing a greater than or equal here for consumption, so consumption was requiring more than you needed.

### DIFF
--- a/SlackMUDRPG/CommandClasses/SMSkill.cs
+++ b/SlackMUDRPG/CommandClasses/SMSkill.cs
@@ -1071,7 +1071,7 @@ namespace SlackMUDRPG.CommandClasses
 			if (smss.StepRequiredObject != "{TARGET}")
 			{
 				string[] itemTypeSplit = smss.StepRequiredObject.Split('.');
-				if (smc.CountOwnedItems(itemTypeSplit[1]) > smss.RequiredObjectAmount)
+				if (smc.CountOwnedItems(itemTypeSplit[1]) >= smss.RequiredObjectAmount)
 				{
 					// if they have enough remove them (i.e. consume them)
 					int numberToConsume = smss.RequiredObjectAmount;


### PR DESCRIPTION
- Adjust skill required item count logic from `>` to `>=`, in other words, having exactly the correct amount should not result in failure.