### PR TITLE
Item overhaul drop and dropall commands

### DIFF
--- a/SlackMUDRPG/CommandClasses/SMCharacter.cs
+++ b/SlackMUDRPG/CommandClasses/SMCharacter.cs
@@ -2059,6 +2059,13 @@ namespace SlackMUDRPG.CommandClasses
 		/// <param name="itemIdentifier">Item identifier.</param>
 		public void DropItem(string itemIdentifier)
 		{
+			// Handle "drop all" command
+			if (itemIdentifier.ToLower() == "all")
+			{
+				this.DropAll();
+				return;
+			}
+
 			// Get the item to drop
 			SMItem itemToDrop = this.GetOwnedItem(itemIdentifier);
 
@@ -2077,6 +2084,22 @@ namespace SlackMUDRPG.CommandClasses
 			// Unable to find the item
 			this.sendMessageToPlayer(this.Formatter.Italic($"Unable to find \"{Utils.SanitiseString(itemIdentifier)}\" to drop!"));
 			return;
+		}
+
+		/// <summary>
+		/// Drops all equipped items into the characters current room. Any item inside equipped containers will remain in the container when it is dropped.
+		/// </summary>
+		public void DropAll()
+		{
+			foreach (SMSlot slot in this.Slots)
+			{
+				if (slot.EquippedItem != null)
+				{
+					this.DropItem(slot.EquippedItem.ItemID);
+				}
+			}
+
+			// TODO handle items in clothing
 		}
 
 		/// <summary>

--- a/SlackMUDRPG/JSON/Commands/Commands.Inventory.json
+++ b/SlackMUDRPG/JSON/Commands/Commands.Inventory.json
@@ -25,6 +25,19 @@
 		"ExampleUsage": "drop wooden stick",
 		"RequiredSkill": null
 	},
+		{
+		"CommandFamily": "Inventory",
+		"CommandName": "dropall",
+		"CommandDescription": "Drops all currently equipped items into your current room. Any equipped containers keep their contents.",
+		"CommandSyntax": "dropall",
+		"ParamsExpression": null,
+		"CommandClass": "SlackMUDRPG.CommandClasses.SMCharacter",
+		"CommandMethod": "DropAll",
+		"PassCommandAsFirstArg": false,
+		"PassUserIDAsFirstArg": false,
+		"ExampleUsage": "dropall",
+		"RequiredSkill": null
+	},
 	{
 		"CommandFamily": "Inventory",
 		"CommandName": "inventory, i",


### PR DESCRIPTION
- Refactor drop command to allow the character to drop any item they own regardless of where it is about their person. The refactoring utilises other item helper functions rather then redefining logic.

- Add 'dropall' (alias 'drop all') command to drop all equipped items in a single command. Items inside equipped containers will remain inside the container when it is dropped.